### PR TITLE
[haskell] switch schedule

### DIFF
--- a/haskell/app/Main.hs
+++ b/haskell/app/Main.hs
@@ -1,23 +1,8 @@
 module Main where
 
-import Data.Time (TimeOfDay (TimeOfDay))
-
-import Schedule (ioNow, isOpen, DailySchedule (Open, Closed, FromTo), WeeklySchedule (Week), Schedule (WeeklySchedule, DailySchedule))
+import Schedule (ioNow)
 
 main :: IO ()
 main = do
     now <- ioNow
     putStrLn ("Hello, Haskell! it is now: " ++ show now)
-
-    let alwaysOpen = DailySchedule Open
-    putStrLn ("this should be open: " ++ show (isOpen alwaysOpen now))
-    let alwaysClosed = DailySchedule Closed
-    putStrLn ("this should be closed: " ++ show (isOpen alwaysClosed now))
-    let ntf = FromTo (TimeOfDay 9 0 0) (TimeOfDay 17 0 0)
-    let nineToFive = DailySchedule ntf
-    putStrLn ("this should be open between 9AM and 5PM: " ++ show (isOpen nineToFive now))
-
-    let standardWorkingWeek = WeeklySchedule (Week Open Open Open Open Open Closed Closed)
-    putStrLn ("this should be open on week days and closed on weekends: " ++ show (isOpen standardWorkingWeek now))
-    let standardWorkingHours = WeeklySchedule (Week ntf ntf ntf ntf ntf Closed Closed)
-    putStrLn ("this should be open on week days between 9AM and 5PM: " ++ show (isOpen standardWorkingHours now))

--- a/haskell/haskell.cabal
+++ b/haskell/haskell.cabal
@@ -52,7 +52,7 @@ extra-doc-files:    CHANGELOG.md
 library schedule-lib
     exposed-modules: Schedule
     hs-source-dirs: lib
-    build-depends: base ^>=4.17, containers > 0.6, time > 1
+    build-depends: base ^>=4.17, containers > 0.6, sorted-list > 0.3, time > 1
     default-language: Haskell2010
 
 common warnings
@@ -72,7 +72,7 @@ executable haskell
     -- other-extensions:
 
     -- Other library packages from which modules are imported.
-    build-depends:    base ^>=4.17, containers > 0.6, time > 1, schedule-lib
+    build-depends:    base ^>=4.17, containers > 0.6, time > 1, sorted-list > 0.3, schedule-lib
 
     -- Directories containing source files.
     hs-source-dirs:   app
@@ -83,6 +83,6 @@ executable haskell
 test-suite tests
     type: exitcode-stdio-1.0
     main-is: ScheduleTest.hs
-    build-depends: base ^>=4.17, HUnit ^>=1.6, containers > 0.6, time > 1, schedule-lib
+    build-depends: base ^>=4.17, HUnit ^>=1.6, containers > 0.6, time > 1, sorted-list > 0.3, schedule-lib
     hs-source-dirs: tests
     default-language: Haskell2010

--- a/haskell/lib/Schedule.hs
+++ b/haskell/lib/Schedule.hs
@@ -1,5 +1,5 @@
 module Schedule (
-    DailySchedule (Open, Closed, FromTo),
+    DailySchedule (Open, Closed, FromTo, Switch),
     WeeklySchedule (Week),
     Schedule (DailySchedule, WeeklySchedule),
 
@@ -13,7 +13,13 @@ import Data.Time (
     TimeOfDay (TimeOfDay),
     getZonedTime, ZonedTime (ZonedTime))
 
-data DailySchedule = Open | Closed | FromTo TimeOfDay TimeOfDay
+import Data.SortedList (SortedList, fromSortedList)
+
+data DailySchedule =
+    Open
+    | Closed
+    | FromTo TimeOfDay TimeOfDay
+    | Switch (SortedList TimeOfDay) -- on each ToD of the list toggles between open and closed, starts closed
 data WeeklySchedule = Week DailySchedule DailySchedule DailySchedule DailySchedule DailySchedule DailySchedule DailySchedule -- 1 daily schedule per day of the week, starts on monday
 
 data Schedule = DailySchedule DailySchedule | WeeklySchedule WeeklySchedule
@@ -22,6 +28,7 @@ isOpenAt :: DailySchedule -> TimeOfDay -> Bool
 isOpenAt Open _= True
 isOpenAt Closed _ = False
 isOpenAt (FromTo from to) t = t >= from && t < to
+isOpenAt (Switch s) t = (odd.length.filter (<= t)) (fromSortedList s)
 
 data WeekTime = WeekTime DayOfWeek TimeOfDay
 weekTime :: LocalTime -> WeekTime

--- a/haskell/tests/ScheduleTest.hs
+++ b/haskell/tests/ScheduleTest.hs
@@ -2,9 +2,10 @@ module Main where
 import Test.HUnit
 import qualified System.Exit as Exit
 
-import Schedule (isOpen, isClosed, DailySchedule (Open, Closed, FromTo), WeeklySchedule (Week), Schedule (WeeklySchedule, DailySchedule))
+import Schedule (isOpen, isClosed, DailySchedule (Open, Closed, FromTo, Switch), WeeklySchedule (Week), Schedule (WeeklySchedule, DailySchedule))
 import Data.Time (Day, TimeOfDay (TimeOfDay), LocalTime (LocalTime), midday, midnight)
 import Data.Time.Calendar.OrdinalDate (fromOrdinalDate)
+import Data.SortedList (toSortedList)
 
 -- date and times
 monday =    fromOrdinalDate 2025 6 -- 1st complete week of 2025
@@ -16,7 +17,9 @@ saturday =  fromOrdinalDate 2025 11
 sunday =    fromOrdinalDate 2025 12
 
 sixAM =   TimeOfDay  6 0 0
-nineAM =  TimeOfDay  9 0 0
+nineAM = TimeOfDay  9 0 0
+onePM = TimeOfDay 13 0 0
+twelveThirtyPM = TimeOfDay 12 30 0
 threePM = TimeOfDay 15 0 0
 fivePM =  TimeOfDay 17 0 0
 eightPM = TimeOfDay 20 0 0
@@ -24,6 +27,7 @@ eightPM = TimeOfDay 20 0 0
 mondayAt6AM = LocalTime monday sixAM
 mondayAt9AM = LocalTime monday nineAM
 mondayAtNoon = LocalTime monday midday
+mondayAtTwelveThirtyPM = LocalTime monday twelveThirtyPM
 mondayAt3PM = LocalTime monday threePM
 mondayAt5PM = LocalTime monday fivePM
 mondayAt8PM = LocalTime monday eightPM
@@ -44,22 +48,37 @@ sundayAtNoon = LocalTime sunday midday
 alwaysOpen = DailySchedule Open
 alwaysClosed = DailySchedule Closed
 nineToFive = FromTo nineAM fivePM
+nineToFiveWithLunchbreak = Switch (toSortedList [nineAM, midday, onePM, fivePM])
 nineToFiveDaily = DailySchedule nineToFive
+nineToFiveWithLunchbreakDaily = DailySchedule nineToFiveWithLunchbreak
 openOnWeekDays = WeeklySchedule (Week Open Open Open Open Open Closed Closed)
 nineToFiveOnWeekDays = WeeklySchedule (Week nineToFive nineToFive nineToFive nineToFive nineToFive Closed Closed)
+
+
 
 -- tests
 -- daily schedules
 dsAlwaysOpenOnMondays = TestCase (assertBool "should be open on any date" (isOpen alwaysOpen mondayAtNoon))
 dsAlwaysClosedOnMondays = TestCase (assertBool "should be close on any date" (isClosed alwaysClosed mondayAtNoon))
 -- FromTo
-dsOpenDuringWorkingHours1 = TestCase (assertBool "should be open @9AM" (isOpen nineToFiveDaily mondayAtNoon))
+dsOpenDuringWorkingHours1 = TestCase (assertBool "should be opening @9AM" (isOpen nineToFiveDaily mondayAt9AM))
 dsOpenDuringWorkingHours2 = TestCase (assertBool "should be open @noon" (isOpen nineToFiveDaily mondayAtNoon))
-dsOpenDuringWorkingHours3 = TestCase (assertBool "should be open @3PM" (isOpen nineToFiveDaily mondayAtNoon))
+dsOpenDuringWorkingHours3 = TestCase (assertBool "should be open @12:30" (isOpen nineToFiveDaily mondayAtTwelveThirtyPM))
+dsOpenDuringWorkingHours4 = TestCase (assertBool "should be open @3PM" (isOpen nineToFiveDaily mondayAt3PM))
 dsClosedOutsideWorkingHours1 = TestCase (assertBool "should be closed @midnight" (isClosed nineToFiveDaily mondayAtNight))
 dsClosedOutsideWorkingHours2 = TestCase (assertBool "should be closed @6AM" (isClosed nineToFiveDaily mondayAt6AM))
 dsClosedOutsideWorkingHours3 = TestCase (assertBool "should be closing @5PM" (isClosed nineToFiveDaily mondayAt5PM))
 dsClosedOutsideWorkingHours4 = TestCase (assertBool "should be closed @8PM" (isClosed nineToFiveDaily mondayAt8PM))
+-- switch
+dsOpenDuringWorkingHoursLunchBreak1 = TestCase (assertBool "should be opening @9AM" (isOpen nineToFiveWithLunchbreakDaily mondayAt9AM))
+dsOpenDuringWorkingHoursLunchBreak2 = TestCase (assertBool "should be closing @noon" (isClosed nineToFiveWithLunchbreakDaily mondayAtNoon))
+dsOpenDuringWorkingHoursLunchBreak3 = TestCase (assertBool "should be closed @3PM" (isClosed nineToFiveWithLunchbreakDaily mondayAtTwelveThirtyPM))
+dsOpenDuringWorkingHoursLunchBreak4 = TestCase (assertBool "should be open @3PM" (isOpen nineToFiveWithLunchbreakDaily mondayAt3PM))
+dsClosedOutsideWorkingHoursLunchBreak1 = TestCase (assertBool "should be closed @midnight" (isClosed nineToFiveWithLunchbreakDaily mondayAtNight))
+dsClosedOutsideWorkingHoursLunchBreak2 = TestCase (assertBool "should be closed @6AM" (isClosed nineToFiveWithLunchbreakDaily mondayAt6AM))
+dsClosedOutsideWorkingHoursLunchBreak3 = TestCase (assertBool "should be closing @5PM" (isClosed nineToFiveWithLunchbreakDaily mondayAt5PM))
+dsClosedOutsideWorkingHoursLunchBreak4 = TestCase (assertBool "should be closed @8PM" (isClosed nineToFiveWithLunchbreakDaily mondayAt8PM))
+
 -- weekly schedules
 wsOpenOnMondays1 = TestCase (assertBool "should be open on a monday" (isOpen openOnWeekDays mondayAtNoon))
 wsOpenOnMondays2 = TestCase (assertBool "should be open on a monday" (isOpen openOnWeekDays mondayAt8PM))
@@ -95,10 +114,19 @@ tests = TestList [
     TestLabel "dsOpenDuringWorkingHours1" dsOpenDuringWorkingHours1,
     TestLabel "dsOpenDuringWorkingHours2" dsOpenDuringWorkingHours2,
     TestLabel "dsOpenDuringWorkingHours3" dsOpenDuringWorkingHours3,
+    TestLabel "dsOpenDuringWorkingHours4" dsOpenDuringWorkingHours4,
     TestLabel "dsClosedOutsideWorkingHours1" dsClosedOutsideWorkingHours1,
     TestLabel "dsClosedOutsideWorkingHours2" dsClosedOutsideWorkingHours2,
     TestLabel "dsClosedOutsideWorkingHours3" dsClosedOutsideWorkingHours3,
     TestLabel "dsClosedOutsideWorkingHours4" dsClosedOutsideWorkingHours4,
+    TestLabel "dsOpenDuringWorkingHoursLunchBreak1" dsOpenDuringWorkingHoursLunchBreak1,
+    TestLabel "dsOpenDuringWorkingHoursLunchBreak2" dsOpenDuringWorkingHoursLunchBreak2,
+    TestLabel "dsOpenDuringWorkingHoursLunchBreak3" dsOpenDuringWorkingHoursLunchBreak3,
+    TestLabel "dsOpenDuringWorkingHoursLunchBreak4" dsOpenDuringWorkingHoursLunchBreak4,
+    TestLabel "dsClosedOutsideWorkingHoursLunchBreak1" dsClosedOutsideWorkingHoursLunchBreak1,
+    TestLabel "dsClosedOutsideWorkingHoursLunchBreak2" dsClosedOutsideWorkingHoursLunchBreak2,
+    TestLabel "dsClosedOutsideWorkingHoursLunchBreak3" dsClosedOutsideWorkingHoursLunchBreak3,
+    TestLabel "dsClosedOutsideWorkingHoursLunchBreak4" dsClosedOutsideWorkingHoursLunchBreak4,
 
     TestLabel "wsOpenOnMondays1" wsOpenOnMondays1,
     TestLabel "wsOpenOnMondays2" wsOpenOnMondays2,


### PR DESCRIPTION
see #28

added daily "switch schedule" where the thing starts closed, and on each time of day of the list given taggles betwwen open and closed

ideal to represent 9 to 5 working hours with a 1h lunchbreak at 12Pm

used a sortedlist lib to ensure the time of day given to switch are in ascending order
i'm not sure i am using it correctly or even if it is needed for my implementation but i feel the problem representation is better this way