### PR TITLE
[haskell] 2 more schedules supported

### DIFF
--- a/haskell/lib/Schedule.hs
+++ b/haskell/lib/Schedule.hs
@@ -2,9 +2,10 @@ module Schedule (
     DailySchedule (Open, Closed, FromTo, Switch),
     WeeklySchedule (Week), MondaysSchedule, TuesdaysSchedule, WednesdaysSchedule, ThursdaysSchedule, FridaysSchedule, SaturdaysSchedule, SundaysSchedule,
     YearlySchedule (Year), PartialYearSchedule (PartialYear),
+    RepeatingDaysSchedule (Repeat), ReferenceDay, DaysPattern,
     ExceptionalSchedule (RegularExceptBetween), BetweenSchedule (Between), RegularSchedule,
     AmendedSchedule (Amended), InitialSchedule, Amendment (Amend), DateOfEffect,
-    Schedule (DailySchedule, WeeklySchedule, YearlySchedule, ExceptionalSchedule, AmendedSchedule),
+    Schedule (DailySchedule, WeeklySchedule, RepeatingDaysSchedule, YearlySchedule, ExceptionalSchedule, AmendedSchedule),
 
     isOpen, isClosed,
     ioNow, isOpenNow, isClosedNow) where
@@ -110,9 +111,12 @@ isOpenOnDay (RegularExceptBetween rs ex) dt = isOpen applicableSchedule dt where
 -- Amended Schedule
 type DateOfEffect = LocalTime
 data Amendment = Amend DateOfEffect Schedule deriving (Show)
+instance Eq Amendment where
+    Amend d _ == Amend e _ = d == e
 compareAmendments :: Amendment -> Amendment -> Ordering
 compareAmendments (Amend d _) (Amend e _) = compare d e
-
+instance Ord Amendment where
+  compare = compareAmendments
 type InitialSchedule = Schedule
 data AmendedSchedule = Amended InitialSchedule (SortedList Amendment) deriving (Show)
 


### PR DESCRIPTION
see #28 

adds RepeatingDaysSchedule for something like
- on day 1: open from 6am to noon
- on day 2: open from noon to 8pm
- on day 3: closed
- repeat this cycle ad nauseam, use 2025-01-01 as reference date

and amendedSchedule for something like
- initial schedule was xxx
- but on march 1st 2025 switch to schedule yyy
- and on september 12th 2027 switch to schedule zzz