### PR TITLE
[rust] add redis for http caching

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     # restart: always
     ports:
       - "5432:5432"
-
     # set shared memory limit when using docker-compose
     shm_size: 128mb
     # or set shared memory limit when deploy via swarm stack
@@ -17,7 +16,7 @@ services:
 
     environment:
       POSTGRES_PASSWORD: postgres
-    
+
   rmq:
     image: rabbitmq:4-management
     ports:
@@ -26,3 +25,9 @@ services:
     volumes:
       - /tank/lulu/volumes/sandbox-rmq/data/:/var/lib/rabbitmq/
       - /tank/lulu/volumes/sandbox-rmq/log/:/var/log/rabbitmq/
+
+  redis:
+    image: redis:latest
+    command: redis-server
+    ports:
+    - 6379:6379

--- a/rust/.env
+++ b/rust/.env
@@ -1,4 +1,5 @@
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
 AMQP_URL=amqp://guest:guest@localhost:5672/%2f
+REDIS_URL=redis://localhost:6379
 SECRET="shh its a secret"
 RMQ_EXCHANGE=rust

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -86,6 +86,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +455,16 @@ dependencies = [
  "der",
  "spki",
  "x509-cert",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1912,6 +1928,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b110459d6e323b7cda23980c46c77157601199c9da6241552b284cd565a7a133"
+dependencies = [
+ "arc-swap",
+ "combine",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.8",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,6 +2409,7 @@ dependencies = [
  "lapin",
  "postgis_diesel",
  "r2d2",
+ "redis",
  "rocket",
  "serde",
  "sha2",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2410,6 +2410,7 @@ dependencies = [
  "lapin",
  "postgis_diesel",
  "r2d2",
+ "rand 0.9.0",
  "redis",
  "rocket",
  "serde",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1938,6 +1938,7 @@ dependencies = [
  "itoa",
  "num-bigint",
  "percent-encoding",
+ "r2d2",
  "ryu",
  "sha1_smol",
  "socket2 0.5.8",

--- a/rust/shell/Cargo.toml
+++ b/rust/shell/Cargo.toml
@@ -18,6 +18,7 @@ lapin = "2.5.2"
 async-global-executor = "3.1.0"
 futures-lite = "2.6.0"
 redis = { version = "0.29.2", features = ["r2d2"] }
+rand = "0.9.0"
 
 [dev-dependencies]
 tokio = "1.44.1"

--- a/rust/shell/Cargo.toml
+++ b/rust/shell/Cargo.toml
@@ -17,6 +17,7 @@ r2d2 = "0.8"
 lapin = "2.5.2"
 async-global-executor = "3.1.0"
 futures-lite = "2.6.0"
+redis = "0.29.2"
 
 [dev-dependencies]
 tokio = "1.44.1"

--- a/rust/shell/Cargo.toml
+++ b/rust/shell/Cargo.toml
@@ -17,7 +17,7 @@ r2d2 = "0.8"
 lapin = "2.5.2"
 async-global-executor = "3.1.0"
 futures-lite = "2.6.0"
-redis = "0.29.2"
+redis = { version = "0.29.2", features = ["r2d2"] }
 
 [dev-dependencies]
 tokio = "1.44.1"

--- a/rust/shell/src/api/mod.rs
+++ b/rust/shell/src/api/mod.rs
@@ -12,24 +12,18 @@ where
     T: Serialize,
 {
     body: Json<T>,
-    etag: Option<String>,
+    etag: String,
 }
 
 #[rocket::async_trait]
 impl<'r, T: Serialize> Responder<'r, 'static> for EtagJson<T> {
     fn respond_to(self, req: &'r Request<'_>) -> rocket::response::Result<'static> {
-        let mut builder = rocket::response::Response::build_from(self.body.respond_to(req)?);
-        let builder = builder
+        rocket::response::Response::build_from(self.body.respond_to(req)?)
             .status(rocket::http::Status::Ok)
-            .header(ContentType::JSON);
-        let builder = match self.etag {
-            Some(tag) => builder.header(Header {
+            .header(ContentType::JSON)
+            .header(Header {
                 name: "ETag".to_string().into(),
-                value: tag.into(),
-            }),
-            None => builder,
-        };
-
-        builder.ok()
+                value: self.etag.into(),
+            }).ok()
     }
 }

--- a/rust/shell/src/api/mod.rs
+++ b/rust/shell/src/api/mod.rs
@@ -1,19 +1,19 @@
 mod post;
 
-
-
 pub use post::*;
 use rocket::http::{ContentType, Header};
-use rocket::response::Responder;
 use rocket::request::Request;
+use rocket::response::Responder;
 use rocket::serde::json::Json;
 use serde::Serialize;
 
-pub struct EtagJson<T> where T: Serialize {
+pub struct EtagJson<T>
+where
+    T: Serialize,
+{
     body: Json<T>,
     etag: Option<String>,
 }
-
 
 #[rocket::async_trait]
 impl<'r, T: Serialize> Responder<'r, 'static> for EtagJson<T> {
@@ -23,8 +23,11 @@ impl<'r, T: Serialize> Responder<'r, 'static> for EtagJson<T> {
             .status(rocket::http::Status::Ok)
             .header(ContentType::JSON);
         let builder = match self.etag {
-            Some(tag) => builder.header(Header { name: "ETag".to_string().into(), value: tag.into()}),
-            None => builder
+            Some(tag) => builder.header(Header {
+                name: "ETag".to_string().into(),
+                value: tag.into(),
+            }),
+            None => builder,
         };
 
         builder.ok()

--- a/rust/shell/src/api/mod.rs
+++ b/rust/shell/src/api/mod.rs
@@ -1,3 +1,27 @@
 mod post;
 
+
+
 pub use post::*;
+use rocket::http::{ContentType, Header};
+use rocket::response::Responder;
+use rocket::request::Request;
+use rocket::serde::json::Json;
+use serde::Serialize;
+
+pub struct EtagJson<T> where T: Serialize {
+    body: Json<T>,
+    etag: String,
+}
+
+
+#[rocket::async_trait]
+impl<'r, T: Serialize> Responder<'r, 'static> for EtagJson<T> {
+    fn respond_to(self, req: &'r Request<'_>) -> rocket::response::Result<'static> {
+        rocket::response::Response::build_from(self.body.respond_to(req)?)
+            .status(rocket::http::Status::Ok)
+            .header(ContentType::JSON)
+            .header(Header { name: "ETag".to_string().into(), value: self.etag.into()})
+            .ok()
+    }
+}

--- a/rust/shell/src/api/mod.rs
+++ b/rust/shell/src/api/mod.rs
@@ -24,6 +24,7 @@ impl<'r, T: Serialize> Responder<'r, 'static> for EtagJson<T> {
             .header(Header {
                 name: "ETag".to_string().into(),
                 value: self.etag.into(),
-            }).ok()
+            })
+            .ok()
     }
 }

--- a/rust/shell/src/api/mod.rs
+++ b/rust/shell/src/api/mod.rs
@@ -12,19 +12,24 @@ where
     T: Serialize,
 {
     body: Json<T>,
-    etag: String,
+    etag: Option<String>,
 }
 
 #[rocket::async_trait]
 impl<'r, T: Serialize> Responder<'r, 'static> for EtagJson<T> {
     fn respond_to(self, req: &'r Request<'_>) -> rocket::response::Result<'static> {
-        rocket::response::Response::build_from(self.body.respond_to(req)?)
+        let mut builder = rocket::response::Response::build_from(self.body.respond_to(req)?);
+        let builder = builder
             .status(rocket::http::Status::Ok)
-            .header(ContentType::JSON)
-            .header(Header {
+            .header(ContentType::JSON);
+        let builder = match self.etag {
+            Some(tag) => builder.header(Header {
                 name: "ETag".to_string().into(),
-                value: self.etag.into(),
-            })
-            .ok()
+                value: tag.into(),
+            }),
+            None => builder,
+        };
+
+        builder.ok()
     }
 }

--- a/rust/shell/src/api/post.rs
+++ b/rust/shell/src/api/post.rs
@@ -1,7 +1,7 @@
 use crate::auth::JwtIdentifiedSubject;
 use crate::db::{self, find_user};
-use crate::redis::{self, match_etag, EtaggedRequest};
 use crate::error::Error;
+use crate::redis::{self, match_etag, EtaggedRequest};
 use crate::ServerState;
 use rocket::serde::{Deserialize, Serialize};
 use rocket::State;
@@ -94,8 +94,6 @@ pub async fn get_posts(
         Some(true) => Err(Error::NotModified),
         _ => Ok(()),
     }?;
-
-
 
     let mut db_conn = db::get_conn(&server_state.db_pool)?;
 

--- a/rust/shell/src/api/post.rs
+++ b/rust/shell/src/api/post.rs
@@ -172,7 +172,6 @@ pub async fn publish_post(
     subject: JwtIdentifiedSubject,
     id: i32,
 ) -> Result<Status, rocket::response::status::Custom<String>> {
-
     let mut conn = db::get_conn(&server_state.db_pool)?;
     let rmq_sender = &server_state.rmq_sender;
 
@@ -213,8 +212,6 @@ pub fn post_post(
     subject: JwtIdentifiedSubject,
     data: Form<NewPost>,
 ) -> Result<Created<Json<Post>>, rocket::response::status::Custom<String>> {
-
-
     let mut conn = db::get_conn(&server_state.db_pool)?;
     let rmq_sender = &server_state.rmq_sender;
 
@@ -293,7 +290,6 @@ pub fn patch_post(
     id: i32,
     data: Form<PatchPost>,
 ) -> Result<NoContent, rocket::response::status::Custom<String>> {
-
     let mut conn = db::get_conn(&server_state.db_pool)?;
     let rmq_sender = &server_state.rmq_sender;
 

--- a/rust/shell/src/api/post.rs
+++ b/rust/shell/src/api/post.rs
@@ -223,7 +223,7 @@ pub fn post_post(
     data: Form<NewPost>,
     if_match: Option<IfMatchHeader>,
 ) -> Result<Created<Json<Post>>, ResponseError> {
-    let cache_key = format!("posts.{}", id).to_string();
+    let cache_key = "posts".to_string();
     let mut redis_conn = redis::get_conn(&server_state.redis_pool)?;
     let use_cache = if_match.map(|er| match_etag(&mut redis_conn, &cache_key, er.etag));
     match use_cache {
@@ -231,7 +231,7 @@ pub fn post_post(
         Some(Ok(true)) => Ok(()),
         _ => Err(Error::PreconditionFailed),
     }?;
-
+    
     let mut conn = db::get_conn(&server_state.db_pool)?;
     let rmq_sender = &server_state.rmq_sender;
 

--- a/rust/shell/src/api/post.rs
+++ b/rust/shell/src/api/post.rs
@@ -113,7 +113,10 @@ pub async fn get_posts(
     })?;
 
     let results = results.into_iter().map(|x| x.into()).collect();
-    let etag = redis::get_etag(&mut redis_conn, &cache_key)?; // i dont want to 500 on a redis error when i have the results available
+    let etag = match redis::get_etag(&mut redis_conn, &cache_key) {
+        Ok(t) => Some(t),
+        _ => None, // i dont want to 500 on a redis error when i have the results available
+    };
 
     let result = EtagJson {
         body: Json(results),
@@ -156,8 +159,10 @@ pub fn get_post(
         }
     })?;
 
-    let etag = redis::get_etag(&mut redis_conn, &cache_key)?; // i dont want to 500 on a redis error when i have the results available
-
+    let etag = match redis::get_etag(&mut redis_conn, &cache_key) {
+        Ok(t) => Some(t),
+        _ => None, // i dont want to 500 on a redis error when i have the results available
+    };
     let result = EtagJson {
         body: Json(result.into()),
         etag: etag,

--- a/rust/shell/src/api/post.rs
+++ b/rust/shell/src/api/post.rs
@@ -113,7 +113,7 @@ pub async fn get_posts(
     })?;
 
     let results = results.into_iter().map(|x| x.into()).collect();
-    let etag = redis::get_etag(&mut redis_conn, &cache_key).unwrap_or(None); // i dont want to 500 on a redis error when i have the results available
+    let etag = redis::get_etag(&mut redis_conn, &cache_key)?; // i dont want to 500 on a redis error when i have the results available
 
     let result = EtagJson {
         body: Json(results),
@@ -156,7 +156,7 @@ pub fn get_post(
         }
     })?;
 
-    let etag = redis::get_etag(&mut redis_conn, &cache_key).unwrap_or(None); // i dont want to 500 on a redis error when i have the results available
+    let etag = redis::get_etag(&mut redis_conn, &cache_key)?; // i dont want to 500 on a redis error when i have the results available
 
     let result = EtagJson {
         body: Json(result.into()),

--- a/rust/shell/src/api/post.rs
+++ b/rust/shell/src/api/post.rs
@@ -231,7 +231,7 @@ pub fn post_post(
         Some(Ok(true)) => Ok(()),
         _ => Err(Error::PreconditionFailed),
     }?;
-    
+
     let mut conn = db::get_conn(&server_state.db_pool)?;
     let rmq_sender = &server_state.rmq_sender;
 

--- a/rust/shell/src/error.rs
+++ b/rust/shell/src/error.rs
@@ -8,6 +8,7 @@ pub enum Error {
     JwtError(jwt::Error),
     LapinError(lapin::Error),
     R2D2Error(r2d2::Error),
+    RedisError(redis::RedisError),
     StdEnvVarError(std::env::VarError),
 
     NotFound,
@@ -54,6 +55,11 @@ impl From<lapin::Error> for Error {
 impl From<r2d2::Error> for Error {
     fn from(value: r2d2::Error) -> Self {
         Error::R2D2Error(value)
+    }
+}
+impl From<redis::RedisError> for Error {
+    fn from(value: redis::RedisError) -> Self {
+        Error::RedisError(value)
     }
 }
 impl From<std::env::VarError> for Error {
@@ -108,6 +114,10 @@ impl From<Error> for rocket::response::status::Custom<String> {
                 format!("error: {:?}", e).to_string(),
             ), // map every adapters error to 500
             Error::R2D2Error(e) => rocket::response::status::Custom(
+                rocket::http::Status::InternalServerError,
+                format!("error: {:?}", e).to_string(),
+            ), // map every adapters error to 500
+            Error::RedisError(e) => rocket::response::status::Custom(
                 rocket::http::Status::InternalServerError,
                 format!("error: {:?}", e).to_string(),
             ), // map every adapters error to 500

--- a/rust/shell/src/error.rs
+++ b/rust/shell/src/error.rs
@@ -156,7 +156,7 @@ impl From<Error> for rocket::response::status::Custom<String> {
             ),
             Error::Gone => {
                 rocket::response::status::Custom(rocket::http::Status::Gone, "gone".to_string())
-            },
+            }
             Error::Unauthorized => rocket::response::status::Custom(
                 rocket::http::Status::Unauthorized,
                 "unauthorized".to_string(),

--- a/rust/shell/src/error.rs
+++ b/rust/shell/src/error.rs
@@ -19,6 +19,7 @@ pub enum Error {
     Conflict,
     Gone,
     NotModified,
+    PreconditionFailed,
 }
 impl From<AuthError> for Error {
     fn from(value: AuthError) -> Self {
@@ -92,10 +93,13 @@ pub enum AuthError {
 
 #[derive(Debug)]
 pub enum HttpError {
-    NoETagHeader,
+    NoIfMatchHeader,
+    NoIfNoneMatchHeader,
 }
 
-impl From<Error> for rocket::response::status::Custom<String> {
+pub type ResponseError = rocket::response::status::Custom<String>;
+
+impl From<Error> for ResponseError {
     fn from(value: Error) -> Self {
         match value {
             Error::AuthError(e) => rocket::response::status::Custom(
@@ -154,9 +158,10 @@ impl From<Error> for rocket::response::status::Custom<String> {
                 rocket::http::Status::Conflict,
                 "conflict".to_string(),
             ),
-            Error::Gone => {
-                rocket::response::status::Custom(rocket::http::Status::Gone, "gone".to_string())
-            }
+            Error::Gone => rocket::response::status::Custom(
+                rocket::http::Status::Gone,
+                "gone".to_string()
+            ),
             Error::Unauthorized => rocket::response::status::Custom(
                 rocket::http::Status::Unauthorized,
                 "unauthorized".to_string(),
@@ -164,6 +169,10 @@ impl From<Error> for rocket::response::status::Custom<String> {
             Error::NotModified => rocket::response::status::Custom(
                 rocket::http::Status::NotModified,
                 "not modified".to_string(),
+            ),
+            Error::PreconditionFailed => rocket::response::status::Custom(
+                rocket::http::Status::PreconditionFailed,
+                "precondition failed".to_string(),
             ),
         }
     }

--- a/rust/shell/src/error.rs
+++ b/rust/shell/src/error.rs
@@ -158,10 +158,9 @@ impl From<Error> for ResponseError {
                 rocket::http::Status::Conflict,
                 "conflict".to_string(),
             ),
-            Error::Gone => rocket::response::status::Custom(
-                rocket::http::Status::Gone,
-                "gone".to_string()
-            ),
+            Error::Gone => {
+                rocket::response::status::Custom(rocket::http::Status::Gone, "gone".to_string())
+            }
             Error::Unauthorized => rocket::response::status::Custom(
                 rocket::http::Status::Unauthorized,
                 "unauthorized".to_string(),

--- a/rust/shell/src/main.rs
+++ b/rust/shell/src/main.rs
@@ -68,12 +68,7 @@ async fn rocket() -> _ {
 
     async_global_executor::spawn(async move {
         for (routing_key, message) in rx {
-            println!("publishing to rmq");
-            let publish = rmq::publish(&rmq_channel_clone, routing_key, message).await;
-            match publish {
-                _ => (), // just dump error
-            };
-            println!("published to rmq");
+            let _ = rmq::publish(&rmq_channel_clone, routing_key, message).await;
         }
     })
     .detach();

--- a/rust/shell/src/main.rs
+++ b/rust/shell/src/main.rs
@@ -9,6 +9,7 @@ mod api;
 mod auth;
 mod db;
 mod error;
+mod redis;
 mod rmq;
 
 pub struct ServerState {

--- a/rust/shell/src/redis.rs
+++ b/rust/shell/src/redis.rs
@@ -28,15 +28,21 @@ pub fn match_etag(conn: &mut RedisConn, key: &String, etag: String) -> Result<bo
 }
 
 pub fn get_etag(conn: &mut RedisConn, key: &String) -> Result<Option<String>, Error> {
-    // use rand::{distr::Alphanumeric, Rng}; // 0.8
-
-    // let etag: String = rand::rng()
-    //     .sample_iter(&Alphanumeric)
-    //     .take(12)
-    //     .map(char::from)
-    //     .collect();
-
     let etag = conn.get::<&String, Option<String>>(key)?;
+
+    Ok(etag)
+}
+
+pub fn refresh_etag(conn: &mut RedisConn, key: &String) -> Result<String, Error> {
+    use rand::{distr::Alphanumeric, Rng}; // 0.8
+
+    let etag: String = rand::rng()
+        .sample_iter(&Alphanumeric)
+        .take(12)
+        .map(char::from)
+        .collect();
+
+    conn.set::<&String, String, ()>(key, etag.clone())?;
 
     Ok(etag)
 }

--- a/rust/shell/src/redis.rs
+++ b/rust/shell/src/redis.rs
@@ -6,7 +6,7 @@ use std::env;
 pub type RedisPool = r2d2::Pool<redis::Client>;
 pub type RedisConn = r2d2::PooledConnection<redis::Client>;
 
-pub fn init_pool()-> Result<RedisPool, Error>  {
+pub fn init_pool() -> Result<RedisPool, Error> {
     dotenv()?;
     let redis_url = env::var("REDIS_URL")?;
     let client = redis::Client::open(redis_url)?;
@@ -47,7 +47,9 @@ fn extract_etag(req: &Request<'_>) -> Result<EtaggedRequest, Error> {
         .get_one("If-None-Match")
         .ok_or(Error::AuthError(AuthError::NoAuthorizationHeader))?;
 
-    Ok(EtaggedRequest { etag: etag.to_string() })
+    Ok(EtaggedRequest {
+        etag: etag.to_string(),
+    })
 }
 
 #[rocket::async_trait]

--- a/rust/shell/src/redis.rs
+++ b/rust/shell/src/redis.rs
@@ -21,14 +21,24 @@ pub fn get_conn(redis_pool: &RedisPool) -> Result<RedisConn, Error> {
     Ok(conn)
 }
 
-pub fn match_etag(conn: &mut RedisConn, key: String, etag: String) -> bool {
-    let cached_etag: &Result<String, Error> = &conn.get(key).map_err(|e| e.into());
+pub fn match_etag(conn: &mut RedisConn, key: &String, etag: String) -> Result<bool, Error> {
+    let cached_etag = &conn.get::<&String, String>(key)?;
 
-    match cached_etag {
-        Ok(tag) if *tag == etag => true,
-        Ok(_) => false,
-        Err(_) => false, // dump error, we dont care
-    }
+    Ok(*cached_etag == etag)
+}
+
+pub fn get_etag(conn: &mut RedisConn, key: &String) -> Result<Option<String>, Error> {
+    // use rand::{distr::Alphanumeric, Rng}; // 0.8
+
+    // let etag: String = rand::rng()
+    //     .sample_iter(&Alphanumeric)
+    //     .take(12)
+    //     .map(char::from)
+    //     .collect();
+
+    let etag = conn.get::<&String, Option<String>>(key)?;
+
+    Ok(etag)
 }
 
 use rocket::{

--- a/rust/shell/src/redis.rs
+++ b/rust/shell/src/redis.rs
@@ -3,22 +3,89 @@ use dotenvy::dotenv;
 use redis::Commands;
 use std::env;
 
-fn do_something() -> Result<(), Error> {
+pub type RedisPool = r2d2::Pool<redis::Client>;
+pub type RedisConn = r2d2::PooledConnection<redis::Client>;
+
+pub fn init_pool()-> Result<RedisPool, Error>  {
     dotenv()?;
     let redis_url = env::var("REDIS_URL")?;
-
     let client = redis::Client::open(redis_url)?;
-    let mut con = client.get_connection()?;
+    let pool = r2d2::Pool::builder().build(client)?;
 
-    /* do something here */
-    con.set("asd", "qwe")?;
-    let val: String = con.get("asd")?;
-    println!("{:?}", val);
-
-    Ok(())
+    Ok(pool)
 }
 
-#[test]
-fn test_redis() {
-    do_something().expect("has done something");
+pub fn get_conn(redis_pool: &RedisPool) -> Result<RedisConn, Error> {
+    let conn: RedisConn = redis_pool.get()?;
+
+    Ok(conn)
+}
+
+pub fn match_etag(conn: &mut RedisConn, key: String, etag: String) -> bool {
+    let cached_etag: &Result<String, Error> = &conn.get(key).map_err(|e| e.into());
+
+    match cached_etag {
+        Ok(tag) if *tag == etag => true,
+        Ok(_) => false,
+        Err(_) => false, // dump error, we dont care
+    }
+}
+
+use rocket::{
+    http::Status,
+    request::{FromRequest, Outcome},
+    Request,
+};
+pub struct EtaggedRequest {
+    pub etag: String,
+}
+
+fn extract_etag(req: &Request<'_>) -> Result<EtaggedRequest, Error> {
+    use super::error::AuthError;
+    let etag = req
+        .headers()
+        .get_one("If-None-Match")
+        .ok_or(Error::AuthError(AuthError::NoAuthorizationHeader))?;
+
+    Ok(EtaggedRequest { etag: etag.to_string() })
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for EtaggedRequest {
+    type Error = super::error::Error;
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let result = extract_etag(req);
+
+        match result {
+            Ok(e) => Outcome::Success(e),
+            Err(e) => Outcome::Error((Status::Unauthorized, e)),
+        }
+    }
+}
+
+mod test {
+    use crate::error::Error;
+    use dotenvy::dotenv;
+    use redis::Commands;
+    use std::env;
+    fn do_something() -> Result<(), Error> {
+        dotenv()?;
+        let redis_url = env::var("REDIS_URL")?;
+
+        let client = redis::Client::open(redis_url)?;
+        let mut con = client.get_connection()?;
+
+        /* do something here */
+        con.set("posts", "qwe")?;
+        let val: String = con.get("posts")?;
+        println!("{:?}", val);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_redis() {
+        do_something().expect("has done something");
+    }
 }

--- a/rust/shell/src/redis.rs
+++ b/rust/shell/src/redis.rs
@@ -64,28 +64,28 @@ impl<'r> FromRequest<'r> for EtaggedRequest {
     }
 }
 
-mod test {
-    use crate::error::Error;
-    use dotenvy::dotenv;
-    use redis::Commands;
-    use std::env;
-    fn do_something() -> Result<(), Error> {
-        dotenv()?;
-        let redis_url = env::var("REDIS_URL")?;
+// mod test {
+//     use crate::error::Error;
+//     use dotenvy::dotenv;
+//     use redis::Commands;
+//     use std::env;
+//     fn do_something() -> Result<(), Error> {
+//         dotenv()?;
+//         let redis_url = env::var("REDIS_URL")?;
 
-        let client = redis::Client::open(redis_url)?;
-        let mut con = client.get_connection()?;
+//         let client = redis::Client::open(redis_url)?;
+//         let mut con = client.get_connection()?;
 
-        /* do something here */
-        con.set("posts", "qwe")?;
-        let val: String = con.get("posts")?;
-        println!("{:?}", val);
+//         /* do something here */
+//         con.set("posts", "qwe")?;
+//         let val: String = con.get("posts")?;
+//         println!("{:?}", val);
 
-        Ok(())
-    }
+//         Ok(())
+//     }
 
-    #[test]
-    fn test_redis() {
-        do_something().expect("has done something");
-    }
-}
+//     #[test]
+//     fn test_redis() {
+//         do_something().expect("has done something");
+//     }
+// }

--- a/rust/shell/src/redis.rs
+++ b/rust/shell/src/redis.rs
@@ -1,0 +1,24 @@
+use crate::error::Error;
+use dotenvy::dotenv;
+use redis::Commands;
+use std::env;
+
+fn do_something() -> Result<(), Error> {
+    dotenv()?;
+    let redis_url = env::var("REDIS_URL")?;
+
+    let client = redis::Client::open(redis_url)?;
+    let mut con = client.get_connection()?;
+
+    /* do something here */
+    con.set("asd", "qwe")?;
+    let val: String = con.get("asd")?;
+    println!("{:?}", val);
+
+    Ok(())
+}
+
+#[test]
+fn test_redis() {
+    do_something().expect("has done something");
+}

--- a/rust/shell/src/redis.rs
+++ b/rust/shell/src/redis.rs
@@ -27,8 +27,10 @@ pub fn match_etag(conn: &mut RedisConn, key: &String, etag: String) -> Result<bo
     Ok(*cached_etag == etag)
 }
 
-pub fn get_etag(conn: &mut RedisConn, key: &String) -> Result<Option<String>, Error> {
-    let etag = conn.get::<&String, Option<String>>(key)?;
+pub fn get_etag(conn: &mut RedisConn, key: &String) -> Result<String, Error> {
+    let etag = conn
+        .get::<&String, Option<String>>(key)?
+        .unwrap_or(refresh_etag(conn, &key)?);
 
     Ok(etag)
 }


### PR DESCRIPTION
see #43 

add redis instance to infra
add connection from rust to redis
use redis to implement a http cache system
for all CRUD endpoints
- R endpoints return header ETag
- R endpoint check if-none-match request header and return 304 not modified when applicable
- if no ETag is available in cache, R endpoint initialises it (\*)
- CUD endpoints refresh ETags that might be impacted
- CUD endpoint check if-match header to throw 412 precondition failed when applicable

> (\*) i did this because rebooting redis clears all cache and i have more R calls than CUD calls. also, after publishing a post is final, it will not accept any modif, so i have no way of refreshing its etag