### PR TITLE
[haskell] serialize/deserialize as bytestring and json

### DIFF
--- a/haskell/haskell.cabal
+++ b/haskell/haskell.cabal
@@ -52,7 +52,7 @@ extra-doc-files:    CHANGELOG.md
 library schedule-lib
     exposed-modules: Schedule
     hs-source-dirs: lib
-    build-depends: base ^>=4.17, containers > 0.6, sorted-list > 0.3, time > 1
+    build-depends: base ^>=4.17, containers > 0.6, sorted-list > 0.3, time > 1, cereal > 0.5
     default-language: Haskell2010
 
 common warnings
@@ -72,7 +72,7 @@ executable haskell
     -- other-extensions:
 
     -- Other library packages from which modules are imported.
-    build-depends:    base ^>=4.17, containers > 0.6, time > 1, sorted-list > 0.3, schedule-lib
+    build-depends:    base ^>=4.17, containers > 0.6, time > 1, sorted-list > 0.3, schedule-lib, cereal > 0.5
 
     -- Directories containing source files.
     hs-source-dirs:   app
@@ -83,6 +83,6 @@ executable haskell
 test-suite tests
     type: exitcode-stdio-1.0
     main-is: ScheduleTest.hs
-    build-depends: base ^>=4.17, HUnit ^>=1.6, containers > 0.6, time > 1, sorted-list > 0.3, schedule-lib
+    build-depends: base ^>=4.17, HUnit ^>=1.6, containers > 0.6, time > 1, sorted-list > 0.3, schedule-lib, cereal > 0.5
     hs-source-dirs: tests
     default-language: Haskell2010

--- a/haskell/haskell.cabal
+++ b/haskell/haskell.cabal
@@ -52,7 +52,7 @@ extra-doc-files:    CHANGELOG.md
 library schedule-lib
     exposed-modules: Schedule
     hs-source-dirs: lib
-    build-depends: base ^>=4.17, containers > 0.6, sorted-list > 0.3, time > 1, cereal > 0.5
+    build-depends: base ^>=4.17, containers > 0.6, sorted-list > 0.3, time > 1, cereal > 0.5, aeson > 2
     default-language: Haskell2010
 
 common warnings
@@ -72,7 +72,7 @@ executable haskell
     -- other-extensions:
 
     -- Other library packages from which modules are imported.
-    build-depends:    base ^>=4.17, containers > 0.6, time > 1, sorted-list > 0.3, schedule-lib, cereal > 0.5
+    build-depends:    base ^>=4.17, containers > 0.6, time > 1, sorted-list > 0.3, schedule-lib, cereal > 0.5, aeson > 2
 
     -- Directories containing source files.
     hs-source-dirs:   app
@@ -83,6 +83,6 @@ executable haskell
 test-suite tests
     type: exitcode-stdio-1.0
     main-is: ScheduleTest.hs
-    build-depends: base ^>=4.17, HUnit ^>=1.6, containers > 0.6, time > 1, sorted-list > 0.3, schedule-lib, cereal > 0.5
+    build-depends: base ^>=4.17, HUnit ^>=1.6, containers > 0.6, time > 1, sorted-list > 0.3, schedule-lib, cereal > 0.5, aeson > 2
     hs-source-dirs: tests
     default-language: Haskell2010

--- a/haskell/tests/ScheduleTest.hs
+++ b/haskell/tests/ScheduleTest.hs
@@ -3,6 +3,7 @@ import Test.HUnit
 import qualified System.Exit as Exit
 
 import Schedule (
+    SortedList(SortedList), toSortedList,
     isOpen, isClosed,
     DailySchedule (Open, Closed, FromTo, Switch),
     WeeklySchedule (Week),
@@ -10,7 +11,8 @@ import Schedule (
     Schedule (WeeklySchedule, DailySchedule, YearlySchedule, ExceptionalSchedule, RepeatingDaysSchedule, AmendedSchedule), PartialYearSchedule (PartialYear), BetweenSchedule (Between), ExceptionalSchedule (RegularExceptBetween), RepeatingDaysSchedule (Repeat), Amendment (Amend), AmendedSchedule (Amended))
 import Data.Time (Day, TimeOfDay (TimeOfDay), LocalTime (LocalTime), midday, midnight, DayOfWeek (Wednesday), )
 import Data.Time.Calendar.OrdinalDate (fromOrdinalDate)
-import Data.SortedList (toSortedList)
+-- import Data.SortedList (toSortedList)
+import Data.Serialize (Serialize, encode, decode)
 
 -- date and times
 monday =    fromOrdinalDate 2025 6 -- 1st complete week of 2025
@@ -217,6 +219,11 @@ procéWithStorm24 = TestCase (assertBool "3rd amendment - procé should be open 
 procéWithStorm25 = TestCase (assertBool "3rd amendment - procé should be open on a summer evening" (isOpen procéWithStorm (LocalTime midsummer eightPM)))
 procéWithStorm26 = TestCase (assertBool "3rd amendment - procé should be closed on a summer night" (isClosed procéWithStorm (LocalTime midsummer midnight)))
 
+-- serialization
+encoded = encode procéWithStorm
+decoded :: Schedule
+Right decoded = decode encoded
+serDe1 = TestCase (assertEqual "procé with storm after ser-de" procéWithStorm decoded)
 
 tests :: Test
 tests = TestList [
@@ -337,9 +344,23 @@ tests = TestList [
     TestLabel "procéWithStorm23" procéWithStorm23,
     TestLabel "procéWithStorm24" procéWithStorm24,
     TestLabel "procéWithStorm25" procéWithStorm25,
-    TestLabel "procéWithStorm26" procéWithStorm26]
+    TestLabel "procéWithStorm26" procéWithStorm26,
+
+    TestLabel "serDe1" serDe1]
+
+
 
 main :: IO ()
 main = do
+    -- let encoded = encode Open
+    -- putStrLn ("serializing daily schedule open: " ++ show encoded)
+    -- let encoded = encode Closed
+    -- putStrLn ("serializing schedule always closed: " ++ show encoded)
+    -- let encoded = encode nineToFiveOnWeekDays
+    -- putStrLn ("serializing weekly schedule: " ++ show encoded)
+    -- putStrLn ("procéWithStorm schedule: " ++ show procéWithStorm)
+    -- putStrLn ("encoded procéWithStorm schedule: " ++ show encoded)
+    -- putStrLn ("decoded procéWithStorm schedule: " ++ show decoded)
+
     result <- runTestTT tests
     if failures result > 0 then Exit.exitFailure else Exit.exitSuccess

--- a/haskell/tests/ScheduleTest.hs
+++ b/haskell/tests/ScheduleTest.hs
@@ -12,7 +12,11 @@ import Schedule (
 import Data.Time (Day, TimeOfDay (TimeOfDay), LocalTime (LocalTime), midday, midnight, DayOfWeek (Wednesday), )
 import Data.Time.Calendar.OrdinalDate (fromOrdinalDate)
 -- import Data.SortedList (toSortedList)
-import Data.Serialize (Serialize, encode, decode)
+import Data.Serialize (Serialize)
+import Data.Aeson ( toJSON, fromJSON, Result(Success))
+import qualified Data.Serialize
+import qualified Data.Aeson
+
 
 -- date and times
 monday =    fromOrdinalDate 2025 6 -- 1st complete week of 2025
@@ -220,10 +224,15 @@ procéWithStorm25 = TestCase (assertBool "3rd amendment - procé should be open 
 procéWithStorm26 = TestCase (assertBool "3rd amendment - procé should be closed on a summer night" (isClosed procéWithStorm (LocalTime midsummer midnight)))
 
 -- serialization
-encoded = encode procéWithStorm
-decoded :: Schedule
-Right decoded = decode encoded
-serDe1 = TestCase (assertEqual "procé with storm after ser-de" procéWithStorm decoded)
+bsSer = Data.Serialize.encode procéWithStorm
+bsDe :: Schedule
+Right bsDe = Data.Serialize.decode bsSer
+serDe1 = TestCase (assertEqual "procéWithStorm after byteString ser-de" procéWithStorm bsDe)
+
+jsonSer = Data.Aeson.encode procéWithMaintenanceWork
+jsonDe :: Schedule
+Just jsonDe = Data.Aeson.decode jsonSer
+serDe2 = TestCase (assertEqual "procéWithMaintenanceWork after json ser-de" procéWithMaintenanceWork jsonDe)
 
 tests :: Test
 tests = TestList [
@@ -346,21 +355,10 @@ tests = TestList [
     TestLabel "procéWithStorm25" procéWithStorm25,
     TestLabel "procéWithStorm26" procéWithStorm26,
 
-    TestLabel "serDe1" serDe1]
-
-
+    TestLabel "serDe1" serDe1,
+    TestLabel "serDe2" serDe2]
 
 main :: IO ()
 main = do
-    -- let encoded = encode Open
-    -- putStrLn ("serializing daily schedule open: " ++ show encoded)
-    -- let encoded = encode Closed
-    -- putStrLn ("serializing schedule always closed: " ++ show encoded)
-    -- let encoded = encode nineToFiveOnWeekDays
-    -- putStrLn ("serializing weekly schedule: " ++ show encoded)
-    -- putStrLn ("procéWithStorm schedule: " ++ show procéWithStorm)
-    -- putStrLn ("encoded procéWithStorm schedule: " ++ show encoded)
-    -- putStrLn ("decoded procéWithStorm schedule: " ++ show decoded)
-
     result <- runTestTT tests
     if failures result > 0 then Exit.exitFailure else Exit.exitSuccess


### PR DESCRIPTION
prerequisite of #41 

derive the right traits and instance the right classes so my schedules are fully serializable which is necessary if i want to either persist or expose them