### PR TITLE
[infra] add healthchecks for infra services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,9 @@ services:
     ports:
       - 8081:8081
     depends_on:
-      - mongo
+      mongo: 
+        condition: service_healthy
+        restart: true
     networks:
       - sandboxes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@ services:
       - 5432:5432
     volumes:
       - /tank/lulu/volumes/sandbox-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      timeout: 10s
     environment:
       POSTGRES_PASSWORD: postgres
     networks:
@@ -19,6 +25,12 @@ services:
     ports:
     - 5672:5672
     - 15672:15672
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      timeout: 10s
     volumes:
       - /tank/lulu/volumes/sandbox-rmq/data/:/var/lib/rabbitmq/
       - /tank/lulu/volumes/sandbox-rmq/log/:/var/log/rabbitmq/
@@ -29,6 +41,12 @@ services:
     image: redis:latest
     restart: always
     command: redis-server
+    healthcheck:
+      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      timeout: 10s
     ports:
     - 6379:6379
     networks:
@@ -46,6 +64,12 @@ services:
     #   MONGO_INITDB_ROOT_PASSWORD: mongo-admin
     ports:
       - 27017:27017
+    healthcheck:
+      test: ["CMD","mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      timeout: 10s
     networks:
       - sandboxes
   mongo-express:
@@ -73,9 +97,15 @@ services:
       - 8001:8000
     restart: always
     depends_on:
-      - postgres
-      - rmq
-      - redis
+      postgres:
+        condition: service_healthy
+        restart: true
+      rmq:
+        condition: service_healthy
+        restart: true
+      redis:
+        condition: service_healthy
+        restart: true
     networks:
       - sandboxes
 
@@ -87,7 +117,9 @@ services:
       - 3001:3000
     restart: always
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+        restart: true
     networks:
       - sandboxes
 


### PR DESCRIPTION
see #55 do not start backend services unless postgres/redis/rmq/mongo are ready and healthy