### PR TITLE
[rust] dispatch sendmail job

### DIFF
--- a/rust/domain/src/usecases/create_post.rs
+++ b/rust/domain/src/usecases/create_post.rs
@@ -2,7 +2,7 @@ use crate::models::{NewPost, NewPostRequest, Role, User};
 
 #[derive(PartialEq, Debug)]
 pub enum CreatePostResult {
-    DoCreateAndNotify(NewPost),
+    DoCreate(NewPost),
     CantCreateAsReader,
 }
 
@@ -14,7 +14,7 @@ pub fn create_post(subject: &User, create_post_request: NewPostRequest) -> Creat
                 body: create_post_request.body,
                 author: subject.clone(),
             };
-            CreatePostResult::DoCreateAndNotify(new_post)
+            CreatePostResult::DoCreate(new_post)
         }
         Role::Reader => CreatePostResult::CantCreateAsReader,
     }
@@ -65,8 +65,8 @@ mod test {
         let result = create_post(&subject, request);
 
         // assert
-        assert!(matches!(result, CreatePostResult::DoCreateAndNotify(_)));
-        if let CreatePostResult::DoCreateAndNotify(new_post) = result {
+        assert!(matches!(result, CreatePostResult::DoCreate(_)));
+        if let CreatePostResult::DoCreate(new_post) = result {
             assert_eq!(new_post.author.id, subject.id);
         }
     }
@@ -90,8 +90,8 @@ mod test {
         let result = create_post(&subject, request);
 
         // assert
-        assert!(matches!(result, CreatePostResult::DoCreateAndNotify(_)));
-        if let CreatePostResult::DoCreateAndNotify(new_post) = result {
+        assert!(matches!(result, CreatePostResult::DoCreate(_)));
+        if let CreatePostResult::DoCreate(new_post) = result {
             assert_eq!(new_post.author.id, subject.id);
         }
     }

--- a/rust/domain/src/usecases/delete_post.rs
+++ b/rust/domain/src/usecases/delete_post.rs
@@ -127,10 +127,7 @@ mod test {
         let result_someone_elses_post = delete_post(&subject, &someone_elses_post);
 
         // assert
-        assert_eq!(
-            result_my_unpublished_post,
-            DeletePostResult::DoDelete(id)
-        );
+        assert_eq!(result_my_unpublished_post, DeletePostResult::DoDelete(id));
         assert_eq!(
             result_my_published_post,
             DeletePostResult::CantDeletePublishedPost
@@ -186,17 +183,8 @@ mod test {
         let result_someone_elses_post = delete_post(&subject, &someone_elses_post);
 
         // assert
-        assert_eq!(
-            result_my_unpublished_post,
-            DeletePostResult::DoDelete(id)
-        );
-        assert_eq!(
-            result_my_published_post,
-            DeletePostResult::DoDelete(id)
-        );
-        assert_eq!(
-            result_someone_elses_post,
-            DeletePostResult::DoDelete(id)
-        );
+        assert_eq!(result_my_unpublished_post, DeletePostResult::DoDelete(id));
+        assert_eq!(result_my_published_post, DeletePostResult::DoDelete(id));
+        assert_eq!(result_someone_elses_post, DeletePostResult::DoDelete(id));
     }
 }

--- a/rust/domain/src/usecases/delete_post.rs
+++ b/rust/domain/src/usecases/delete_post.rs
@@ -2,7 +2,7 @@ use crate::models::{Post, Role, User};
 
 #[derive(PartialEq, Debug)]
 pub enum DeletePostResult {
-    DoDeleteAndNotify(i32),
+    DoDelete(i32),
     CantDeleteAsReader,
     CantDeletePublishedPost,
     CantDeleteAnotherOnesPost,
@@ -12,8 +12,8 @@ pub fn delete_post(subject: &User, post: &Post) -> DeletePostResult {
         Role::Reader => DeletePostResult::CantDeleteAsReader,
         Role::Writer if subject.id != post.author.id => DeletePostResult::CantDeleteAnotherOnesPost,
         Role::Writer if post.published => DeletePostResult::CantDeletePublishedPost,
-        Role::Writer => DeletePostResult::DoDeleteAndNotify(post.id),
-        Role::Admin => DeletePostResult::DoDeleteAndNotify(post.id),
+        Role::Writer => DeletePostResult::DoDelete(post.id),
+        Role::Admin => DeletePostResult::DoDelete(post.id),
     }
 }
 
@@ -129,7 +129,7 @@ mod test {
         // assert
         assert_eq!(
             result_my_unpublished_post,
-            DeletePostResult::DoDeleteAndNotify(id)
+            DeletePostResult::DoDelete(id)
         );
         assert_eq!(
             result_my_published_post,
@@ -188,15 +188,15 @@ mod test {
         // assert
         assert_eq!(
             result_my_unpublished_post,
-            DeletePostResult::DoDeleteAndNotify(id)
+            DeletePostResult::DoDelete(id)
         );
         assert_eq!(
             result_my_published_post,
-            DeletePostResult::DoDeleteAndNotify(id)
+            DeletePostResult::DoDelete(id)
         );
         assert_eq!(
             result_someone_elses_post,
-            DeletePostResult::DoDeleteAndNotify(id)
+            DeletePostResult::DoDelete(id)
         );
     }
 }

--- a/rust/domain/src/usecases/edit_post.rs
+++ b/rust/domain/src/usecases/edit_post.rs
@@ -252,8 +252,7 @@ mod test {
             result_diff_title_same_body,
             EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_same_body
-        {
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_same_body {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, Some(different_title.to_string()));
             assert_eq!(edition.body, None);
@@ -271,8 +270,7 @@ mod test {
             result_same_title_diff_body,
             EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_same_title_diff_body
-        {
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_same_title_diff_body {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, None);
             assert_eq!(edition.body, Some(different_body.to_string()));
@@ -281,8 +279,7 @@ mod test {
             result_diff_title_diff_body,
             EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_diff_body
-        {
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_diff_body {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, Some(different_title.to_string()));
             assert_eq!(edition.body, Some(different_body.to_string()));
@@ -365,8 +362,7 @@ mod test {
             result_diff_title_same_body,
             EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_same_body
-        {
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_same_body {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, Some(different_title.to_string()));
             assert_eq!(edition.body, None);
@@ -384,8 +380,7 @@ mod test {
             result_same_title_diff_body,
             EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_same_title_diff_body
-        {
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_same_title_diff_body {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, None);
             assert_eq!(edition.body, Some(different_body.to_string()));
@@ -394,8 +389,7 @@ mod test {
             result_diff_title_diff_body,
             EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_diff_body
-        {
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_diff_body {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, Some(different_title.to_string()));
             assert_eq!(edition.body, Some(different_body.to_string()));

--- a/rust/domain/src/usecases/edit_post.rs
+++ b/rust/domain/src/usecases/edit_post.rs
@@ -2,7 +2,7 @@ use crate::models::{Post, PostEdition, Role, User};
 
 #[derive(PartialEq, Debug)]
 pub enum EditPostResult {
-    DoUpdateAndNotify(i32, PostEdition),
+    DoUpdate(i32, PostEdition),
     NothingToUpdate,
     CantEditAnotherOnesPost,
     CantEditPublishedPost,
@@ -33,7 +33,7 @@ pub fn edit_post(subject: &User, post: &Post, request: PostEdition) -> EditPostR
 
     let result = check_subject
         .or(check_edits)
-        .or(Some(EditPostResult::DoUpdateAndNotify(post.id, edits)))
+        .or(Some(EditPostResult::DoUpdate(post.id, edits)))
         .unwrap();
 
     result
@@ -241,18 +241,18 @@ mod test {
         // assert
         assert!(matches!(
             result_diff_title_no_body,
-            EditPostResult::DoUpdateAndNotify(_, _)
+            EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdateAndNotify(id_to_edit, edition) = result_diff_title_no_body {
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_no_body {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, Some(different_title.to_string()));
             assert_eq!(edition.body, None);
         }
         assert!(matches!(
             result_diff_title_same_body,
-            EditPostResult::DoUpdateAndNotify(_, _)
+            EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdateAndNotify(id_to_edit, edition) = result_diff_title_same_body
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_same_body
         {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, Some(different_title.to_string()));
@@ -260,18 +260,18 @@ mod test {
         }
         assert!(matches!(
             result_no_title_diff_body,
-            EditPostResult::DoUpdateAndNotify(_, _)
+            EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdateAndNotify(id_to_edit, edition) = result_no_title_diff_body {
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_no_title_diff_body {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, None);
             assert_eq!(edition.body, Some(different_body.to_string()));
         }
         assert!(matches!(
             result_same_title_diff_body,
-            EditPostResult::DoUpdateAndNotify(_, _)
+            EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdateAndNotify(id_to_edit, edition) = result_same_title_diff_body
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_same_title_diff_body
         {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, None);
@@ -279,9 +279,9 @@ mod test {
         }
         assert!(matches!(
             result_diff_title_diff_body,
-            EditPostResult::DoUpdateAndNotify(_, _)
+            EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdateAndNotify(id_to_edit, edition) = result_diff_title_diff_body
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_diff_body
         {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, Some(different_title.to_string()));
@@ -354,18 +354,18 @@ mod test {
         // assert
         assert!(matches!(
             result_diff_title_no_body,
-            EditPostResult::DoUpdateAndNotify(_, _)
+            EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdateAndNotify(id_to_edit, edition) = result_diff_title_no_body {
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_no_body {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, Some(different_title.to_string()));
             assert_eq!(edition.body, None);
         }
         assert!(matches!(
             result_diff_title_same_body,
-            EditPostResult::DoUpdateAndNotify(_, _)
+            EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdateAndNotify(id_to_edit, edition) = result_diff_title_same_body
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_same_body
         {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, Some(different_title.to_string()));
@@ -373,18 +373,18 @@ mod test {
         }
         assert!(matches!(
             result_no_title_diff_body,
-            EditPostResult::DoUpdateAndNotify(_, _)
+            EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdateAndNotify(id_to_edit, edition) = result_no_title_diff_body {
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_no_title_diff_body {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, None);
             assert_eq!(edition.body, Some(different_body.to_string()));
         }
         assert!(matches!(
             result_same_title_diff_body,
-            EditPostResult::DoUpdateAndNotify(_, _)
+            EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdateAndNotify(id_to_edit, edition) = result_same_title_diff_body
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_same_title_diff_body
         {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, None);
@@ -392,9 +392,9 @@ mod test {
         }
         assert!(matches!(
             result_diff_title_diff_body,
-            EditPostResult::DoUpdateAndNotify(_, _)
+            EditPostResult::DoUpdate(_, _)
         ));
-        if let EditPostResult::DoUpdateAndNotify(id_to_edit, edition) = result_diff_title_diff_body
+        if let EditPostResult::DoUpdate(id_to_edit, edition) = result_diff_title_diff_body
         {
             assert_eq!(id_to_edit, id);
             assert_eq!(edition.title, Some(different_title.to_string()));

--- a/rust/domain/src/usecases/publish_post.rs
+++ b/rust/domain/src/usecases/publish_post.rs
@@ -14,7 +14,9 @@ pub fn publish_post(subject: &User, post: &Post) -> PublishPostResult {
         Reader => PublishPostResult::CantPublishAsReader,
         Writer if subject.id != post.author.id => PublishPostResult::CantPublishAnotherOnesPost,
         _ if post.published => PublishPostResult::CantPublishAlreadyPublishedPost,
-        Admin if subject.id != post.author.id => PublishPostResult::DoPublishAndNotifyAuthor(post.id, post.author.clone()),
+        Admin if subject.id != post.author.id => {
+            PublishPostResult::DoPublishAndNotifyAuthor(post.id, post.author.clone())
+        }
         _ => PublishPostResult::DoPublish(post.id),
     }
 }
@@ -190,10 +192,7 @@ mod test {
             result_someone_elses_post,
             PublishPostResult::DoPublishAndNotifyAuthor(id, someoneelse)
         );
-        assert_eq!(
-            result_my_unpublished_post,
-            PublishPostResult::DoPublish(id)
-        );
+        assert_eq!(result_my_unpublished_post, PublishPostResult::DoPublish(id));
         assert_eq!(
             result_my_published_post,
             PublishPostResult::CantPublishAlreadyPublishedPost

--- a/rust/shell/src/auth.rs
+++ b/rust/shell/src/auth.rs
@@ -80,14 +80,20 @@ impl<'r> FromRequest<'r> for JwtIdentifiedSubject {
 
 // #[test]
 // fn test_sign_token() {
-//     let subject = "john@d.oe";
+//     use dotenvy::dotenv;
+//     match dotenv() {
+//         Ok(_) => println!("loaded local .env file"),
+//         Err(_) => println!("no local .env file to load"),
+//     };
+//     let subject = "lucien@bert.in";
 //     let result = _sign_token(subject.into());
 
 //     match result {
 //         Ok(token) => println!("token: {}", token),
 //         Err(e) => println!("error {:?}", e)
 //     };
-// }#[test]
+// }
+// #[test]
 // fn test_verify_token() {
 //     let token_str = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsdWNpZW5AYmVydC5pbiJ9.MQ2AtPRuMhZuu84jFpjbnZF3tMREpSi51YEU6yq8KBI";
 //     let result = verify_token(token_str);


### PR DESCRIPTION
dispatch message to rmq with `job.sendmail` routing key when an admin publishes the post of another writer

this message is caught by the go mailer micro service and it sends the mail

part of #57 
part of #44