### PR TITLE
[go] domain events logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 .env.dc
+
+go-logs

--- a/README.md
+++ b/README.md
@@ -126,11 +126,13 @@ The dev env for this stack is by far the worst of all the sandboxes, just stay w
 
 ## Go
 
-Very basic micro service that listens to rmq and sends mails, allowing for macro services to just trigger an email by publishing the right message to RMQ. `go build`, `go run` and tutti quanti
+Very basic micro service that listens to rmq and do stuff, allowing for macro services to just publish to RMQ and hope someone is listening.
 
-maybe i can leverage go's powerful routine feature to register several rmq subs at the same time
+stuff done as of now
+- binds exchange `rust` with key `job.send-mail` to queue `go-mailer` ; on message trigger an email send
+- binds exchange `rust` with key `evt.#l` to queue `go-logger` ; on message logs the event to a log file
 
-the part binding it to rmq is not yet done
+`go build`, `go run` and tutti quanti
 
 ## Python
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,6 +180,8 @@ services:
     deploy:
       replicas: 1
     # restart: always
+    volumes:
+      - /tank/lulu/volumes/sandbox-go/logs/:/app/logs
     networks:
       - sandboxes
     depends_on:

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -1,3 +1,4 @@
 m
 .env
 .env.dc
+logs

--- a/go/rmq.go
+++ b/go/rmq.go
@@ -111,7 +111,7 @@ func subToRmq(wg *sync.WaitGroup) {
 		defer wg.Done()
 	}
 	go func() {
-		f, err := os.OpenFile("./logs", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+		f, err := os.OpenFile("./logs/logfile.log", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 		if err != nil {
 			panic(err)
 		}

--- a/go/rmq.go
+++ b/go/rmq.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"time"
 
 	"os"
 
@@ -28,7 +29,7 @@ func subToRmq(wg *sync.WaitGroup) {
 		defer wg.Done()
 	}
 
-	q, err := ch.QueueDeclare(
+	mails_queue, err := ch.QueueDeclare(
 		"go-mailer", // name
 		false,       // durable
 		false,       // delete when unused
@@ -37,26 +38,53 @@ func subToRmq(wg *sync.WaitGroup) {
 		nil,         // arguments
 	)
 	if err != nil {
-		log.Panicf("Failed to declare a queue %s", err)
+		log.Panicf("Failed to declare mailer queue %s", err)
 		defer wg.Done()
 	}
-	deliveries, err := ch.Consume(
-		q.Name, // queue
-		"",     // consumer
-		false,  // auto-ack
-		false,  // exclusive
-		false,  // no-local
-		false,  // no-wait
-		nil,    // args
+	ch.QueueBind(
+		mails_queue.Name, // queue name
+		"job.sendmail",   // routing key
+		"rust",           // exchange
+		false,            // no-wait
+		nil,              // arguments
+	)
+
+	logs_queue, err := ch.QueueDeclare(
+		"go-logger", // name
+		false,       // durable
+		false,       // delete when unused
+		false,       // exclusive
+		false,       // no-wait
+		nil,         // arguments
+	)
+	if err != nil {
+		log.Panicf("Failed to declare logger queue %s", err)
+		defer wg.Done()
+	}
+	ch.QueueBind(
+		logs_queue.Name, // queue name
+		"evt.#",         // routing key
+		"rust",          // exchange
+		false,           // no-wait
+		nil,             // arguments
+	)
+	mail_jobs, err := ch.Consume(
+		mails_queue.Name, // queue
+		"",               // consumer
+		false,            // auto-ack
+		false,            // exclusive
+		false,            // no-local
+		false,            // no-wait
+		nil,              // args
 	)
 	if err != nil {
 		log.Panicf("Failed to register a consumer %s", err)
 		defer wg.Done()
 	}
 	go func() {
-		for d := range deliveries {
+		for d := range mail_jobs {
 			log.Printf("message recieve with body: %s", d.Body)
-			err := handleDelivery(d)
+			err := handleMailJob(d)
 			if err != nil {
 				log.Printf("failed to handle message: %s", err)
 				d.Reject(false) // might throw but idc
@@ -68,11 +96,41 @@ func subToRmq(wg *sync.WaitGroup) {
 		}
 
 	}()
+
+	logs, err := ch.Consume(
+		logs_queue.Name, // queue
+		"",              // consumer
+		true,            // auto-ack
+		false,           // exclusive
+		false,           // no-local
+		false,           // no-wait
+		nil,             // args
+	)
+	if err != nil {
+		log.Panicf("Failed to register a consumer %s", err)
+		defer wg.Done()
+	}
+	go func() {
+		f, err := os.OpenFile("./logs", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+		if err != nil {
+			panic(err)
+		}
+
+		for d := range logs {
+			log.Printf("message recieve with key: %s - body: %s", d.RoutingKey, d.Body)
+			err := handleEventLog(d, f)
+			if err != nil {
+				log.Printf("couldnt write to file: %s", err)
+			}
+		}
+
+	}()
+
 	// defer ch.Close() // never close
 	// defer wg.Done() // never be done
 }
 
-func handleDelivery(d amqp.Delivery) error {
+func handleMailJob(d amqp.Delivery) error {
 	var err error
 	var parsedMessage map[string]string
 	err = json.Unmarshal([]byte(d.Body), &parsedMessage)
@@ -89,4 +147,12 @@ func handleDelivery(d amqp.Delivery) error {
 	}
 
 	return nil
+}
+
+func handleEventLog(d amqp.Delivery, f *os.File) error {
+	l := fmt.Sprintf("%s: %s - %s\n", time.Now(), d.RoutingKey, d.Body)
+
+	_, err := f.WriteString(l)
+
+	return err
 }

--- a/rust/shell/src/api/post.rs
+++ b/rust/shell/src/api/post.rs
@@ -268,7 +268,8 @@ pub fn post_post(
             CantCreateAsReader => Err(Error::Forbidden),
             DoCreate(new_post) => {
                 let post_id = db::insert_new_post(conn, new_post)?;
-                let _ = rmq_sender.send(("evt.post.created".to_string(), format!("id: {}", post_id)));
+                let _ =
+                    rmq_sender.send(("evt.post.created".to_string(), format!("id: {}", post_id)));
 
                 let cache_key = "posts".to_string();
                 let mut redis_conn = redis::get_conn(&server_state.redis_pool)?;
@@ -319,7 +320,8 @@ pub fn delete_post(
             CantDeleteAsReader => Err(Error::Forbidden),
             DoDelete(post_id) => {
                 db::delete_post(conn, post_id)?;
-                let _ = rmq_sender.send(("evt.post.deleted".to_string(), format!("id: {}", post_id)));
+                let _ =
+                    rmq_sender.send(("evt.post.deleted".to_string(), format!("id: {}", post_id)));
 
                 let cache_keys = ["posts".to_string(), format!("posts.{}", id).to_string()];
                 for cache_key in cache_keys {
@@ -370,7 +372,8 @@ pub fn patch_post(
             NothingToUpdate => Ok(()), // treat it as Ok for idempotency purpose
             DoUpdate(post_id, post_edition) => {
                 db::update_post(conn, post_id, post_edition)?;
-                let _ = rmq_sender.send(("evt.post.updated".to_string(), format!("id: {}", post_id)));
+                let _ =
+                    rmq_sender.send(("evt.post.updated".to_string(), format!("id: {}", post_id)));
 
                 let cache_keys = ["posts".to_string(), format!("posts.{}", id).to_string()];
                 for cache_key in cache_keys {

--- a/rust/shell/src/api/post.rs
+++ b/rust/shell/src/api/post.rs
@@ -205,7 +205,7 @@ pub async fn publish_post(
             CantPublishAlreadyPublishedPost => Ok(()), // treat it as Ok for idempotency purpose
             DoPublish(post_id) => {
                 db::publish_post(conn, post_id)?;
-                let _ = rmq_sender.send(("post.published".to_string(), format!("id: {}", post_id)));
+                let _ = rmq_sender.send(("evt.post.published".to_string(), format!("id: {}", post_id)));
 
                 let cache_keys = ["posts".to_string(), format!("posts.{}", id).to_string()];
                 let mut redis_conn = redis::get_conn(&server_state.redis_pool)?;
@@ -217,7 +217,7 @@ pub async fn publish_post(
             },
             DoPublishAndNotifyAuthor(post_id, author) => {
                 db::publish_post(conn, post_id)?;
-                let _ = rmq_sender.send(("post.published".to_string(), format!("id: {}", post_id)));
+                let _ = rmq_sender.send(("evt.post.published".to_string(), format!("id: {}", post_id)));
 
                 let cache_keys = ["posts".to_string(), format!("posts.{}", id).to_string()];
                 let mut redis_conn = redis::get_conn(&server_state.redis_pool)?;
@@ -268,7 +268,7 @@ pub fn post_post(
             CantCreateAsReader => Err(Error::Forbidden),
             DoCreate(new_post) => {
                 let post_id = db::insert_new_post(conn, new_post)?;
-                let _ = rmq_sender.send(("post.created".to_string(), format!("id: {}", post_id)));
+                let _ = rmq_sender.send(("evt.post.created".to_string(), format!("id: {}", post_id)));
 
                 let cache_key = "posts".to_string();
                 let mut redis_conn = redis::get_conn(&server_state.redis_pool)?;
@@ -319,7 +319,7 @@ pub fn delete_post(
             CantDeleteAsReader => Err(Error::Forbidden),
             DoDelete(post_id) => {
                 db::delete_post(conn, post_id)?;
-                let _ = rmq_sender.send(("post.deleted".to_string(), format!("id: {}", post_id)));
+                let _ = rmq_sender.send(("evt.post.deleted".to_string(), format!("id: {}", post_id)));
 
                 let cache_keys = ["posts".to_string(), format!("posts.{}", id).to_string()];
                 for cache_key in cache_keys {
@@ -370,7 +370,7 @@ pub fn patch_post(
             NothingToUpdate => Ok(()), // treat it as Ok for idempotency purpose
             DoUpdate(post_id, post_edition) => {
                 db::update_post(conn, post_id, post_edition)?;
-                let _ = rmq_sender.send(("post.updated".to_string(), format!("id: {}", post_id)));
+                let _ = rmq_sender.send(("evt.post.updated".to_string(), format!("id: {}", post_id)));
 
                 let cache_keys = ["posts".to_string(), format!("posts.{}", id).to_string()];
                 for cache_key in cache_keys {


### PR DESCRIPTION
part of #44 

when rust emits a domain event to rmq, with routing key `evt.#`, it is listened by go and logged to a file on disk