### PR TITLE
[nestjs] rmq publish

### DIFF
--- a/go/rmq.go
+++ b/go/rmq.go
@@ -75,6 +75,13 @@ func subToRmq(wg *sync.WaitGroup) {
 		false,           // no-wait
 		nil,             // arguments
 	)
+	ch.QueueBind(
+		logs_queue.Name, // queue name
+		"evt.#",         // routing key
+		"nestjs",        // exchange
+		false,           // no-wait
+		nil,             // arguments
+	)
 	mail_jobs, err := ch.Consume(
 		mails_queue.Name, // queue
 		"",               // consumer

--- a/nestjs/apps/server/src/cat/cat.module.ts
+++ b/nestjs/apps/server/src/cat/cat.module.ts
@@ -5,18 +5,11 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { Cat, CatSchema } from './cat.entity';
 import { PublisherService } from './publisher.service';
 
-const AMQP_HOST = process.env.AMQP_HOST as string;
-const AMQP_USER = process.env.AMQP_USER as string;
-const AMQP_PWD = process.env.AMQP_PWD as string;
-
-
 @Module({
-  imports: [
-    MongooseModule.forFeature([{ name: Cat.name, schema: CatSchema }]),
-  ],
+  imports: [MongooseModule.forFeature([{ name: Cat.name, schema: CatSchema }])],
   providers: [
     DbService,
-    CatResolver, 
+    CatResolver,
     {
       provide: PublisherService,
       useFactory: async () => {
@@ -24,7 +17,7 @@ const AMQP_PWD = process.env.AMQP_PWD as string;
         await publisher.init();
         return publisher;
       },
-    }
+    },
   ],
 })
 export class CatModule {}

--- a/nestjs/apps/server/src/cat/cat.module.ts
+++ b/nestjs/apps/server/src/cat/cat.module.ts
@@ -1,11 +1,30 @@
 import { Module } from '@nestjs/common';
-import { CatService } from './cat.service';
+import { DbService } from './db.service';
 import { CatResolver } from './cat.resolver';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Cat, CatSchema } from './cat.entity';
+import { PublisherService } from './publisher.service';
+
+const AMQP_HOST = process.env.AMQP_HOST as string;
+const AMQP_USER = process.env.AMQP_USER as string;
+const AMQP_PWD = process.env.AMQP_PWD as string;
+
 
 @Module({
-  imports: [MongooseModule.forFeature([{ name: Cat.name, schema: CatSchema }])],
-  providers: [CatService, CatResolver],
+  imports: [
+    MongooseModule.forFeature([{ name: Cat.name, schema: CatSchema }]),
+  ],
+  providers: [
+    DbService,
+    CatResolver, 
+    {
+      provide: PublisherService,
+      useFactory: async () => {
+        const publisher = new PublisherService();
+        await publisher.init();
+        return publisher;
+      },
+    }
+  ],
 })
 export class CatModule {}

--- a/nestjs/apps/server/src/cat/cat.resolver.ts
+++ b/nestjs/apps/server/src/cat/cat.resolver.ts
@@ -1,23 +1,30 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { Cat, CreateCatDto } from './cat.entity';
-import { CatService } from './cat.service';
+import { DbService } from './db.service';
+import { PublisherService } from './publisher.service';
 
 @Resolver(() => Cat)
 export class CatResolver {
-  constructor(private catService: CatService) {}
+  constructor(
+    private db: DbService,
+    private publisher: PublisherService,
+  ) {}
 
   @Query(() => [Cat])
   async cats() {
-    return await this.catService.findAll();
+    return await this.db.findAllCats();
   }
 
   @Query(() => Cat)
   async cat(@Args('name', { type: () => String }) name: string) {
-    return await this.catService.findByName(name);
+    return await this.db.findCatByName(name);
   }
 
   @Mutation(() => Cat)
   async createCat(@Args('cat') cat: CreateCatDto) {
-    return await this.catService.create(cat);
+    const createdCat = await this.db.createCat(cat);
+    this.publisher.publishCatCreated(createdCat);
+
+    return createdCat;
   }
 }

--- a/nestjs/apps/server/src/cat/db.service.ts
+++ b/nestjs/apps/server/src/cat/db.service.ts
@@ -4,14 +4,14 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Cat, CreateCatDto } from './cat.entity';
 
 @Injectable()
-export class CatService {
+export class DbService {
   constructor(@InjectModel(Cat.name) private catModel: Model<Cat>) {}
 
-  async findAll(): Promise<Cat[]> {
+  async findAllCats(): Promise<Cat[]> {
     return this.catModel.find().exec();
   }
 
-  async findByName(name: string): Promise<Cat | null> {
+  async findCatByName(name: string): Promise<Cat | null> {
     return this.catModel
       .findOne({
         name: name,
@@ -19,7 +19,7 @@ export class CatService {
       .exec();
   }
 
-  async create(createCatDto: CreateCatDto): Promise<Cat> {
+  async createCat(createCatDto: CreateCatDto): Promise<Cat> {
     const createdCat = new this.catModel(createCatDto);
     return createdCat.save();
   }

--- a/nestjs/apps/server/src/cat/publisher.service.ts
+++ b/nestjs/apps/server/src/cat/publisher.service.ts
@@ -1,0 +1,33 @@
+import { connect, Channel } from "amqplib";
+import { Injectable } from "@nestjs/common";
+import { Cat } from "./cat.entity";
+
+const AMQP_HOST = process.env.AMQP_HOST as string;
+const AMQP_USER = process.env.AMQP_USER as string;
+const AMQP_PWD = process.env.AMQP_PWD as string;
+const rmqUrl = `amqp://${AMQP_USER}:${AMQP_PWD}@${AMQP_HOST}:5672`;
+const EXCHANGE_NAME = process.env.RMQ_EXCHANGE as string;
+
+@Injectable()
+export class PublisherService {
+  private channel: Channel;
+  async init() {
+    console.log(`⌛️ Connecting to Rabbit-MQ Server at ${rmqUrl}`);
+    const connection = await connect(rmqUrl);
+    console.log(`✅ Rabbit MQ Connection is ready`);
+    this.channel = await connection.createChannel();
+    console.log(`🛸 Created RabbitMQ Channel successfully`);
+    await this.channel.assertExchange(EXCHANGE_NAME, "topic", {
+      durable: true,
+    });
+  }
+
+  publishCatCreated(cat: Cat) {
+    this.channel.publish(
+      EXCHANGE_NAME,
+      'evt.cat.created',
+      Buffer.from(JSON.stringify(cat)),
+    );
+    console.log('message published')
+  }
+}

--- a/nestjs/apps/server/src/cat/publisher.service.ts
+++ b/nestjs/apps/server/src/cat/publisher.service.ts
@@ -1,6 +1,6 @@
-import { connect, Channel } from "amqplib";
-import { Injectable } from "@nestjs/common";
-import { Cat } from "./cat.entity";
+import { connect, Channel } from 'amqplib';
+import { Injectable } from '@nestjs/common';
+import { Cat } from './cat.entity';
 
 const AMQP_HOST = process.env.AMQP_HOST as string;
 const AMQP_USER = process.env.AMQP_USER as string;
@@ -17,7 +17,7 @@ export class PublisherService {
     console.log(`✅ Rabbit MQ Connection is ready`);
     this.channel = await connection.createChannel();
     console.log(`🛸 Created RabbitMQ Channel successfully`);
-    await this.channel.assertExchange(EXCHANGE_NAME, "topic", {
+    await this.channel.assertExchange(EXCHANGE_NAME, 'topic', {
       durable: true,
     });
   }
@@ -28,6 +28,6 @@ export class PublisherService {
       'evt.cat.created',
       Buffer.from(JSON.stringify(cat)),
     );
-    console.log('message published')
+    console.log('message published');
   }
 }

--- a/nestjs/package-lock.json
+++ b/nestjs/package-lock.json
@@ -35,6 +35,7 @@
         "@nestjs/testing": "^11.1.0",
         "@swc/cli": "^0.6.0",
         "@swc/core": "^1.10.7",
+        "@types/amqplib": "^0.10.7",
         "@types/express": "^5.0.0",
         "@types/geojson": "^7946.0.16",
         "@types/jest": "^29.5.14",
@@ -3526,6 +3527,16 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@types/amqplib": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.10.7.tgz",
+      "integrity": "sha512-IVj3avf9AQd2nXCx0PGk/OYq7VmHiyNxWFSb5HhU9ATh+i+gHWvVcljFTcTWQ/dyHJCTrzCixde+r/asL2ErDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/nestjs/package.json
+++ b/nestjs/package.json
@@ -57,6 +57,7 @@
     "@nestjs/testing": "^11.1.0",
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.10.7",
+    "@types/amqplib": "^0.10.7",
     "@types/express": "^5.0.0",
     "@types/geojson": "^7946.0.16",
     "@types/jest": "^29.5.14",


### PR DESCRIPTION
closes #133 

i have no idea how `@nestjs/microservices` is supposed to work, i tried using it to connect to the rmq instance and publish/consume messages but it just dont work yall.

i suspect it adds an abstraction layer and works well when the whole micro services architecture uses nestjs and you want to abstract part of the infrastructure. I have some notes, though

- the point of microservices arch is to have the least amount of coupling between each service. forcing me to have all my services in nestjs goes against the pattern
- having an abstraction layer is a boon when you want to be able to swap the abstracted thing. Are people migrating from rmq to kafka to redis on a regular basis ? is i a relevant enough usecase to design a whole library around it ?
- i believe microservices arch is inadequate 99% of the time. It split domain in chunks that make no sense in isolation. it overcomplexifies everything (codebase, production, monitoring, CI/CD, ...) for gains that are hardly worth it _when_ they materialize
- the modular approch of nestjs is good for gradually enriching and enhacing a macroservice (i import this feature module, and then this one, and then this other one, ...). this go against what you should do in a microservice arch, where to add a feature you add a microservice, you dont fatten an existing one. I shouldn't be able to import external module when launching a nest microservice
