### PR TITLE
[rust] minor code factoring

### DIFF
--- a/rust/shell/src/api/mod.rs
+++ b/rust/shell/src/api/mod.rs
@@ -60,7 +60,10 @@ where
 }
 impl<T: Serialize> EtagJson<T> {
     pub fn new(body: T, etag: Option<String>) -> Self {
-        Self { body: Json(body), etag: etag }
+        Self {
+            body: Json(body),
+            etag: etag,
+        }
     }
 }
 
@@ -254,8 +257,11 @@ pub async fn build_server() -> Result<Rocket<Build>, Error> {
     Ok(server)
 }
 
-
-pub fn check_none_match(conn: &mut RedisConn, cache_key: &String, if_none_match_header: Option<IfNoneMatchHeader>) -> Result<(), Error> {
+pub fn check_none_match(
+    conn: &mut RedisConn,
+    cache_key: &String,
+    if_none_match_header: Option<IfNoneMatchHeader>,
+) -> Result<(), Error> {
     let use_cache = if_none_match_header.map(|er| redis::match_etag(conn, cache_key, er.etag));
     match use_cache {
         Some(Ok(true)) => Err(HttpError::NotModified.into()),
@@ -265,7 +271,11 @@ pub fn check_none_match(conn: &mut RedisConn, cache_key: &String, if_none_match_
 
     Ok(())
 }
-pub fn check_match(conn: &mut RedisConn, cache_key: &String, if_match_header: Option<IfMatchHeader>) -> Result<(), Error> {
+pub fn check_match(
+    conn: &mut RedisConn,
+    cache_key: &String,
+    if_match_header: Option<IfMatchHeader>,
+) -> Result<(), Error> {
     let use_cache = if_match_header.map(|er| redis::match_etag(conn, cache_key, er.etag));
     match use_cache {
         None => Ok(()),
@@ -277,7 +287,10 @@ pub fn check_match(conn: &mut RedisConn, cache_key: &String, if_match_header: Op
     Ok(())
 }
 
-pub fn resolve_agent(conn: &mut PgConnection, subject: JwtIdentifiedSubject) -> Result<Agent, Error> {
+pub fn resolve_agent(
+    conn: &mut PgConnection,
+    subject: JwtIdentifiedSubject,
+) -> Result<Agent, Error> {
     let agent = db::find_user(conn, subject.email)?;
     let agent = agent.ok_or(HttpError::Unauthorized)?;
     let agent = Agent::User(agent);

--- a/rust/shell/src/api/mod.rs
+++ b/rust/shell/src/api/mod.rs
@@ -56,6 +56,11 @@ where
     body: Json<T>,
     etag: Option<String>,
 }
+impl<T: Serialize> EtagJson<T> {
+    pub fn new(body: T, etag: Option<String>) -> Self {
+        Self { body: Json(body), etag: etag }
+    }
+}
 
 #[rocket::async_trait]
 impl<'r, T: Serialize> Responder<'r, 'static> for EtagJson<T> {

--- a/rust/shell/src/api/mod.rs
+++ b/rust/shell/src/api/mod.rs
@@ -3,11 +3,13 @@ mod place;
 mod post;
 
 use crate::db::DbPool;
-use crate::error::Error;
-use crate::redis::RedisPool;
+use crate::error::{Error, HttpError};
+use crate::redis::{RedisConn, RedisPool};
 use crate::rmqpub::RmQPublisher;
 use crate::{db, redis, rmqpub};
 
+use diesel::PgConnection;
+use domain::models::Agent;
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::http::{ContentType, Header};
 use rocket::request::Request;
@@ -250,4 +252,44 @@ pub async fn build_server() -> Result<Rocket<Build>, Error> {
         });
 
     Ok(server)
+}
+
+
+pub fn check_none_match(conn: &mut RedisConn, cache_key: &String, if_none_match_header: Option<IfNoneMatchHeader>) -> Result<(), Error> {
+    let use_cache = if_none_match_header.map(|er| redis::match_etag(conn, cache_key, er.etag));
+    match use_cache {
+        Some(Ok(true)) => Err(HttpError::NotModified.into()),
+        _ => Ok(()),
+    }
+    .map_err(|e: Error| e)?;
+
+    Ok(())
+}
+pub fn check_match(conn: &mut RedisConn, cache_key: &String, if_match_header: Option<IfMatchHeader>) -> Result<(), Error> {
+    let use_cache = if_match_header.map(|er| redis::match_etag(conn, cache_key, er.etag));
+    match use_cache {
+        None => Ok(()),
+        Some(Ok(true)) => Ok(()),
+        _ => Err(HttpError::PreconditionFailed.into()),
+    }
+    .map_err(|e: Error| e)?;
+
+    Ok(())
+}
+
+pub fn resolve_agent(conn: &mut PgConnection, subject: JwtIdentifiedSubject) -> Result<Agent, Error> {
+    let agent = db::find_user(conn, subject.email)?;
+    let agent = agent.ok_or(HttpError::Unauthorized)?;
+    let agent = Agent::User(agent);
+
+    Ok(agent)
+}
+
+pub fn get_etag_safe(conn: &mut RedisConn, cache_key: &String) -> Option<String> {
+    let etag = match redis::get_etag(conn, cache_key) {
+        Ok(t) => Some(t),
+        _ => None,
+    };
+
+    etag
 }

--- a/rust/shell/src/api/place.rs
+++ b/rust/shell/src/api/place.rs
@@ -1,5 +1,8 @@
 use super::error::ResponseError;
-use super::{check_none_match, get_etag_safe, ServerState, resolve_agent, EtagJson, IfNoneMatchHeader, JwtIdentifiedSubject};
+use super::{
+    check_none_match, get_etag_safe, resolve_agent, EtagJson, IfNoneMatchHeader,
+    JwtIdentifiedSubject, ServerState,
+};
 use crate::db::{self, DbConn};
 use crate::error::Error;
 use crate::redis;


### PR DESCRIPTION
i had several 3-6L code blocks repeating in all my endpoints functions for resolving the agent for example or checking with redis if i should exit early on a 304/412 http status. This PR just extracted this code and factored it across all endpoints

Rust is so good for that sort of operations, i havent tested it but i am confident it works. chef kiss emoji