### PR TITLE
[rust] from request

### DIFF
--- a/rust/shell/src/api/mod.rs
+++ b/rust/shell/src/api/mod.rs
@@ -301,43 +301,43 @@ impl<'r> FromRequest<'r> for &'r RmQPublisher {
 }
 
 use std::ops::{Deref, DerefMut};
-struct AgentWrapper(Agent);
-impl Deref for AgentWrapper {
-    type Target = Agent;
+// struct AgentWrapper(Agent);
+// impl Deref for AgentWrapper {
+//     type Target = Agent;
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+//     fn deref(&self) -> &Self::Target {
+//         &self.0
+//     }
+// }
 
-impl DerefMut for AgentWrapper {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-#[rocket::async_trait]
-impl<'r> FromRequest<'r> for AgentWrapper {
-    type Error = super::error::Error;
+// impl DerefMut for AgentWrapper {
+//     fn deref_mut(&mut self) -> &mut Self::Target {
+//         &mut self.0
+//     }
+// }
+// #[rocket::async_trait]
+// impl<'r> FromRequest<'r> for AgentWrapper {
+//     type Error = super::error::Error;
 
-    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let subject = request.guard::<JwtIdentifiedSubject>().await.succeeded();
-        let r_state = request
-            .guard::<&'r State<ServerState>>()
-            .await
-            .succeeded()
-            .ok_or(super::error::Error::Error);
-        let r_db_conn: Result<db::DbConn, Error> =
-            r_state.and_then(|s| s.db_pool.get().map_err(|e| e.into()));
-        // here i am resolving agent outside of the transaction i will open in my request handler
-        // it is a bit incoherent to do it this way, it goes against why i wrapp all my IO in the db transaction in the first place
-        // tbh im not convinced it is a good idea
-        let r_agent = r_db_conn.and_then(|mut conn| resolve_agent(&mut conn, subject));
-        match r_agent {
-            Err(e) => Outcome::Error((Status::InternalServerError, e)),
-            Ok(agent) => Outcome::Success(AgentWrapper(agent)),
-        }
-    }
-}
+//     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+//         let subject = request.guard::<JwtIdentifiedSubject>().await.succeeded();
+//         let r_state = request
+//             .guard::<&'r State<ServerState>>()
+//             .await
+//             .succeeded()
+//             .ok_or(super::error::Error::Error);
+//         let r_db_conn: Result<db::DbConn, Error> =
+//             r_state.and_then(|s| s.db_pool.get().map_err(|e| e.into()));
+//         // here i am resolving agent outside of the transaction i will open in my request handler
+//         // it is a bit incoherent to do it this way, it goes against why i wrapp all my IO in the db transaction in the first place
+//         // tbh im not convinced it is a good idea
+//         let r_agent = r_db_conn.and_then(|mut conn| resolve_agent(&mut conn, subject));
+//         match r_agent {
+//             Err(e) => Outcome::Error((Status::InternalServerError, e)),
+//             Ok(agent) => Outcome::Success(AgentWrapper(agent)),
+//         }
+//     }
+// }
 
 pub struct ServerState {
     pub db_pool: DbPool,

--- a/rust/shell/src/api/mod.rs
+++ b/rust/shell/src/api/mod.rs
@@ -301,43 +301,6 @@ impl<'r> FromRequest<'r> for &'r RmQPublisher {
 }
 
 use std::ops::{Deref, DerefMut};
-// struct AgentWrapper(Agent);
-// impl Deref for AgentWrapper {
-//     type Target = Agent;
-
-//     fn deref(&self) -> &Self::Target {
-//         &self.0
-//     }
-// }
-
-// impl DerefMut for AgentWrapper {
-//     fn deref_mut(&mut self) -> &mut Self::Target {
-//         &mut self.0
-//     }
-// }
-// #[rocket::async_trait]
-// impl<'r> FromRequest<'r> for AgentWrapper {
-//     type Error = super::error::Error;
-
-//     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-//         let subject = request.guard::<JwtIdentifiedSubject>().await.succeeded();
-//         let r_state = request
-//             .guard::<&'r State<ServerState>>()
-//             .await
-//             .succeeded()
-//             .ok_or(super::error::Error::Error);
-//         let r_db_conn: Result<db::DbConn, Error> =
-//             r_state.and_then(|s| s.db_pool.get().map_err(|e| e.into()));
-//         // here i am resolving agent outside of the transaction i will open in my request handler
-//         // it is a bit incoherent to do it this way, it goes against why i wrapp all my IO in the db transaction in the first place
-//         // tbh im not convinced it is a good idea
-//         let r_agent = r_db_conn.and_then(|mut conn| resolve_agent(&mut conn, subject));
-//         match r_agent {
-//             Err(e) => Outcome::Error((Status::InternalServerError, e)),
-//             Ok(agent) => Outcome::Success(AgentWrapper(agent)),
-//         }
-//     }
-// }
 
 pub struct ServerState {
     pub db_pool: DbPool,

--- a/rust/shell/src/api/mod.rs
+++ b/rust/shell/src/api/mod.rs
@@ -328,6 +328,9 @@ impl<'r> FromRequest<'r> for AgentWrapper {
             .ok_or(super::error::Error::Error);
         let r_db_conn: Result<db::DbConn, Error> =
             r_state.and_then(|s| s.db_pool.get().map_err(|e| e.into()));
+        // here i am resolving agent outside of the transaction i will open in my request handler
+        // it is a bit incoherent to do it this way, it goes against why i wrapp all my IO in the db transaction in the first place
+        // tbh im not convinced it is a good idea
         let r_agent = r_db_conn.and_then(|mut conn| resolve_agent(&mut conn, subject));
         match r_agent {
             Err(e) => Outcome::Error((Status::InternalServerError, e)),

--- a/rust/shell/src/api/mod.rs
+++ b/rust/shell/src/api/mod.rs
@@ -238,11 +238,16 @@ impl<'r> FromRequest<'r> for DbConnWrapper {
     type Error = super::error::Error;
 
     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let r_state = request.guard::<&'r State<ServerState>>().await.succeeded().ok_or(super::error::Error::Error);
-        let r_conn:Result<db::DbConn, Error> = r_state.and_then(|s| s.db_pool.get().map_err(|e| e.into()));
+        let r_state = request
+            .guard::<&'r State<ServerState>>()
+            .await
+            .succeeded()
+            .ok_or(super::error::Error::Error);
+        let r_conn: Result<db::DbConn, Error> =
+            r_state.and_then(|s| s.db_pool.get().map_err(|e| e.into()));
         match r_conn {
             Ok(c) => Outcome::Success(DbConnWrapper(c)),
-            Err(e) => Outcome::Error((Status::InternalServerError, e))
+            Err(e) => Outcome::Error((Status::InternalServerError, e)),
         }
     }
 }
@@ -264,11 +269,16 @@ impl<'r> FromRequest<'r> for RedisConnWrapper {
     type Error = super::error::Error;
 
     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let r_state = request.guard::<&'r State<ServerState>>().await.succeeded().ok_or(super::error::Error::Error);
-        let r_conn: Result<RedisConn, Error> = r_state.and_then(|s| s.redis_pool.get().map_err(|e| e.into()));
+        let r_state = request
+            .guard::<&'r State<ServerState>>()
+            .await
+            .succeeded()
+            .ok_or(super::error::Error::Error);
+        let r_conn: Result<RedisConn, Error> =
+            r_state.and_then(|s| s.redis_pool.get().map_err(|e| e.into()));
         match r_conn {
             Ok(c) => Outcome::Success(RedisConnWrapper(c)),
-            Err(e) => Outcome::Error((Status::InternalServerError, e))
+            Err(e) => Outcome::Error((Status::InternalServerError, e)),
         }
     }
 }
@@ -277,11 +287,15 @@ impl<'r> FromRequest<'r> for &'r RmQPublisher {
     type Error = super::error::Error;
 
     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let r_state = request.guard::<&'r State<ServerState>>().await.succeeded().ok_or(super::error::Error::Error);
+        let r_state = request
+            .guard::<&'r State<ServerState>>()
+            .await
+            .succeeded()
+            .ok_or(super::error::Error::Error);
         let r_pub: Result<&'r RmQPublisher, Error> = r_state.map(|s| &s.rmq_publisher);
         match r_pub {
             Ok(p) => Outcome::Success(p),
-            Err(e) => Outcome::Error((Status::InternalServerError, e))
+            Err(e) => Outcome::Error((Status::InternalServerError, e)),
         }
     }
 }
@@ -307,8 +321,13 @@ impl<'r> FromRequest<'r> for AgentWrapper {
 
     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         let subject = request.guard::<JwtIdentifiedSubject>().await.succeeded();
-        let r_state = request.guard::<&'r State<ServerState>>().await.succeeded().ok_or(super::error::Error::Error);
-        let r_db_conn:Result<db::DbConn, Error> = r_state.and_then(|s| s.db_pool.get().map_err(|e| e.into()));
+        let r_state = request
+            .guard::<&'r State<ServerState>>()
+            .await
+            .succeeded()
+            .ok_or(super::error::Error::Error);
+        let r_db_conn: Result<db::DbConn, Error> =
+            r_state.and_then(|s| s.db_pool.get().map_err(|e| e.into()));
         let r_agent = r_db_conn.and_then(|mut conn| resolve_agent(&mut conn, subject));
         match r_agent {
             Err(e) => Outcome::Error((Status::InternalServerError, e)),
@@ -316,8 +335,6 @@ impl<'r> FromRequest<'r> for AgentWrapper {
         }
     }
 }
-
-
 
 pub struct ServerState {
     pub db_pool: DbPool,

--- a/rust/shell/src/api/place.rs
+++ b/rust/shell/src/api/place.rs
@@ -1,6 +1,8 @@
 use super::error::ResponseError;
 use super::{
-    check_none_match, get_etag_safe, AgentWrapper, DbConnWrapper, EtagJson, IfNoneMatchHeader, RedisConnWrapper };
+    check_none_match, get_etag_safe, AgentWrapper, DbConnWrapper, EtagJson, IfNoneMatchHeader,
+    RedisConnWrapper,
+};
 use crate::db::{self, DbConn};
 use crate::error::Error;
 use domain::models::Agent;
@@ -108,10 +110,7 @@ pub async fn get_places_geojson(
     Ok(result)
 }
 
-fn fetch_places(
-    db_conn: &mut DbConn,
-    agent: &Agent,
-) -> Result<Vec<domain::models::Place>, Error> {
+fn fetch_places(db_conn: &mut DbConn, agent: &Agent) -> Result<Vec<domain::models::Place>, Error> {
     let results = db_conn.build_transaction().read_only().run(
         |conn| -> Result<Vec<domain::models::Place>, Error> {
             let result = domain::usecases::consult_places(&agent);

--- a/rust/shell/src/db/mod.rs
+++ b/rust/shell/src/db/mod.rs
@@ -30,6 +30,7 @@ pub fn init_pool() -> Result<DbPool, Error> {
     Ok(pool)
 }
 
+#[cfg(feature = "rmqsub")]
 pub fn get_conn(db_pool: &DbPool) -> Result<DbConn, Error> {
     let conn: DbConn = db_pool.get()?;
 

--- a/rust/shell/src/redis.rs
+++ b/rust/shell/src/redis.rs
@@ -17,7 +17,7 @@ pub fn init_pool() -> Result<RedisPool, Error> {
 
     Ok(pool)
 }
-
+#[cfg(feature = "rmqsub")]
 pub fn get_conn(redis_pool: &RedisPool) -> Result<RedisConn, Error> {
     let conn: RedisConn = redis_pool.get()?;
 


### PR DESCRIPTION
see #140 items 2 and 3

i would like to not make endpoints functions inject the server state to get access to the connection pools for redis and/or the db

```rust
#[post("/posts", data = "<data>")]
pub fn post_post(
    server_state: &State<ServerState>, // this
    subject: Option<JwtIdentifiedSubject>,
    data: Form<NewPost>,
    if_match: Option<IfMatchHeader>,
) -> Result<Created<Json<Post>>, ResponseError> {
    let cache_key = "posts".to_string();
    let mut redis_conn = redis::get_conn(&server_state.redis_pool)?; // used here
```

so this PR adds from request impl for db_conn, redis_conn and rmq_pub

i did then reverted item 3 "resolve agent from request and unpub JwtIdentifiedSubject" for 2 reasons
- agent resolution (with db query) happened before check for the etag match condition and it'd be betetr for perfs to not do IO operations before knowing if these operations are needed, but thats not the most important reason because i think i coukd manasge to resolve cache condition in from request guard at some point in the future so this point could be invalidated
- i got one db query running outside of the transactions i was opening, i mean whats the point of a transaction if some stuff is outside. sure this operation was readonly, and on data that was not very volatile so it's relatively risk free, but i'd rather stay coherent right now