### PR TITLE
[infra] minor docker optims

### DIFF
--- a/blazor/Dockerfile
+++ b/blazor/Dockerfile
@@ -1,15 +1,21 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS builder
 WORKDIR /App
 
-# Copy everything
-COPY . ./
+# Copy sln and proj files
+COPY blazor.dockersln ./blazor.sln
+COPY Domain/Domain.fsproj Domain/packages.lock.json ./Domain/
+COPY Shell/Shell.csproj Shell/packages.lock.json ./Shell/
 # Restore as distinct layers
 RUN dotnet restore
+
+# Copy source code
+COPY ./Domain ./Domain
+COPY ./Shell ./Shell
 # Build and publish a release
 RUN dotnet publish ./Shell -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runner
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-bookworm-slim AS runner
 WORKDIR /App
 COPY --from=builder /App/out .
 

--- a/blazor/Dockerfile
+++ b/blazor/Dockerfile
@@ -3,8 +3,8 @@ WORKDIR /App
 
 # Copy sln and proj files
 COPY blazor.dockersln ./blazor.sln
-COPY Domain/Domain.fsproj Domain/packages.lock.json ./Domain/
-COPY Shell/Shell.csproj Shell/packages.lock.json ./Shell/
+COPY Domain/Domain.fsproj ./Domain/
+COPY Shell/Shell.csproj ./Shell/
 # Restore as distinct layers
 RUN dotnet restore
 

--- a/blazor/blazor.dockersln
+++ b/blazor/blazor.dockersln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Domain", "Domain\Domain.fsproj", "{DC4AD05A-D661-4A63-8F2C-2029F89A69AE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shell", "Shell\Shell.csproj", "{A57A2420-B82E-427A-AF63-529BD59E43CE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A57A2420-B82E-427A-AF63-529BD59E43CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A57A2420-B82E-427A-AF63-529BD59E43CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A57A2420-B82E-427A-AF63-529BD59E43CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A57A2420-B82E-427A-AF63-529BD59E43CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC4AD05A-D661-4A63-8F2C-2029F89A69AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC4AD05A-D661-4A63-8F2C-2029F89A69AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC4AD05A-D661-4A63-8F2C-2029F89A69AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC4AD05A-D661-4A63-8F2C-2029F89A69AE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/rust/App.Dockerfile
+++ b/rust/App.Dockerfile
@@ -54,8 +54,8 @@ FROM debian:bookworm-slim
 WORKDIR /usr/src/app
 
 # Copy the built binary from the previous stage
-COPY --from=builder /usr/src/app/target/release/shell /app/
-COPY --from=builder /usr/src/app/target/site /app/site
+COPY --from=builder /usr/src/app/target/release/shell ./
+COPY --from=builder /usr/src/app/target/site ./site
 
 # Command to run the application
-CMD ["/app/shell"]
+CMD ["./shell"]

--- a/rust/shell/src/app/mod.rs
+++ b/rust/shell/src/app/mod.rs
@@ -20,6 +20,7 @@ pub fn shell(options: LeptosOptions) -> impl IntoView {
         <html lang="en">
             <head>
                 <meta charset="utf-8"/>
+                <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
                 <meta name="viewport" content="width=device-width, initial-scale=1"/>
                 <AutoReload options=options.clone() />
                 <HydrationScripts options/>


### PR DESCRIPTION
couldnt do #149 complitely cuz i dont understand how to use the lockfiles because
- the lockfile i generate locally are for .netsdk 9.0.1
- the lockfile during the docker build use .netsdk 9.0.3
- i cant install .net 9.0.3 locally, the most i get is 9.0.106
- so i cant get an version env similar to the docker build so it just dont work
- also, upgrading my version of dotnet may havec borked my local dotnet setup, i cant restore my sln right now and i dont care to fix it