### PR TITLE
[rust] error responder

### DIFF
--- a/rust/shell/src/api/error.rs
+++ b/rust/shell/src/api/error.rs
@@ -16,13 +16,13 @@ impl<'r> Responder<'r, 'static> for Error {
             | Error::LapinError(_)
             | Error::SendError(_)
             | Error::RedisError(_)
-            | Error::SerializeError(_) => Status::InternalServerError, // 500
+            | Error::SerializeError(_)
+            | Error::Error => Status::InternalServerError, // 500
 
             #[cfg(feature = "rmqsub")]
             Error::GeoJSONSerdeError(_)
             | Error::GeoJsonError(_)
-            | Error::FromUTF8Error(_)
-            | Error::Error => Status::InternalServerError, // 500
+            | Error::FromUTF8Error(_) => Status::InternalServerError, // 500
 
             Error::JwtError(_) | Error::AuthError(_) => Status::Unauthorized, // 401
 

--- a/rust/shell/src/api/error.rs
+++ b/rust/shell/src/api/error.rs
@@ -1,43 +1,42 @@
-use rocket::response::{self, Response, Responder};
-use rocket::request::Request;
 use crate::error::{Error, HttpError};
+use rocket::request::Request;
+use rocket::response::{self, Responder, Response};
 
 #[rocket::async_trait]
 impl<'r> Responder<'r, 'static> for Error {
     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
         let status = match self {
-            Error::DotEnvyError(_) |
-            Error::StdEnvVarError(_) |
-            Error::DieselConnectionError(_) |
-            Error::DieselQueryError(_) |
-            Error::HMacError(_) |
-            Error::R2D2Error(_) |
-            Error::LapinError(_) |
-            Error::SendError(_) |
-            Error::RedisError(_) |
-            Error::SerializeError(_) => rocket::http::Status::InternalServerError, // 500
-            
-            #[cfg(feature = "rmqsub")]
-            Error::GeoJSONSerdeError(_) |
-            Error::GeoJsonError(_) |
-            Error::FromUTF8Error(_) |
-            Error::Error => rocket::http::Status::InternalServerError, // 500
+            Error::DotEnvyError(_)
+            | Error::StdEnvVarError(_)
+            | Error::DieselConnectionError(_)
+            | Error::DieselQueryError(_)
+            | Error::HMacError(_)
+            | Error::R2D2Error(_)
+            | Error::LapinError(_)
+            | Error::SendError(_)
+            | Error::RedisError(_)
+            | Error::SerializeError(_) => rocket::http::Status::InternalServerError, // 500
 
-            Error::JwtError(_) |
-            Error::AuthError(_) => rocket::http::Status::Unauthorized, // 401
+            #[cfg(feature = "rmqsub")]
+            Error::GeoJSONSerdeError(_)
+            | Error::GeoJsonError(_)
+            | Error::FromUTF8Error(_)
+            | Error::Error => rocket::http::Status::InternalServerError, // 500
+
+            Error::JwtError(_) | Error::AuthError(_) => rocket::http::Status::Unauthorized, // 401
 
             Error::HttpError(HttpError::Conflict) => rocket::http::Status::Conflict, // 409
             Error::HttpError(HttpError::Forbidden) => rocket::http::Status::Forbidden, // 403
-            Error::HttpError(HttpError::Gone) => rocket::http::Status::Gone, // 410
+            Error::HttpError(HttpError::Gone) => rocket::http::Status::Gone,         // 410
             Error::HttpError(HttpError::NotFound) => rocket::http::Status::NotFound, // 404
             Error::HttpError(HttpError::NotModified) => rocket::http::Status::NotModified, // 301
-            Error::HttpError(HttpError::PreconditionFailed) => rocket::http::Status::PreconditionFailed, // 412
+            Error::HttpError(HttpError::PreconditionFailed) => {
+                rocket::http::Status::PreconditionFailed
+            } // 412
             Error::HttpError(HttpError::Unauthorized) => rocket::http::Status::Unauthorized, // 401
-            Error::HttpError(_) => rocket::http::Status::InternalServerError, // 500
+            Error::HttpError(_) => rocket::http::Status::InternalServerError,        // 500
         };
 
-        Response::build()
-            .status(status)
-            .ok()
+        Response::build().status(status).ok()
     }
 }

--- a/rust/shell/src/api/error.rs
+++ b/rust/shell/src/api/error.rs
@@ -5,6 +5,7 @@ use rocket::response::{self, Responder, Response};
 #[rocket::async_trait]
 impl<'r> Responder<'r, 'static> for Error {
     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
+        use rocket::http::Status;
         let status = match self {
             Error::DotEnvyError(_)
             | Error::StdEnvVarError(_)
@@ -15,26 +16,26 @@ impl<'r> Responder<'r, 'static> for Error {
             | Error::LapinError(_)
             | Error::SendError(_)
             | Error::RedisError(_)
-            | Error::SerializeError(_) => rocket::http::Status::InternalServerError, // 500
+            | Error::SerializeError(_) => Status::InternalServerError, // 500
 
             #[cfg(feature = "rmqsub")]
             Error::GeoJSONSerdeError(_)
             | Error::GeoJsonError(_)
             | Error::FromUTF8Error(_)
-            | Error::Error => rocket::http::Status::InternalServerError, // 500
+            | Error::Error => Status::InternalServerError, // 500
 
-            Error::JwtError(_) | Error::AuthError(_) => rocket::http::Status::Unauthorized, // 401
+            Error::JwtError(_) | Error::AuthError(_) => Status::Unauthorized, // 401
 
-            Error::HttpError(HttpError::Conflict) => rocket::http::Status::Conflict, // 409
-            Error::HttpError(HttpError::Forbidden) => rocket::http::Status::Forbidden, // 403
-            Error::HttpError(HttpError::Gone) => rocket::http::Status::Gone,         // 410
-            Error::HttpError(HttpError::NotFound) => rocket::http::Status::NotFound, // 404
-            Error::HttpError(HttpError::NotModified) => rocket::http::Status::NotModified, // 301
-            Error::HttpError(HttpError::PreconditionFailed) => {
-                rocket::http::Status::PreconditionFailed
-            } // 412
-            Error::HttpError(HttpError::Unauthorized) => rocket::http::Status::Unauthorized, // 401
-            Error::HttpError(_) => rocket::http::Status::InternalServerError,        // 500
+            Error::HttpError(HttpError::NotModified) => Status::NotModified, // 301
+
+            Error::HttpError(HttpError::Unauthorized) => Status::Unauthorized, // 401
+            Error::HttpError(HttpError::Forbidden) => Status::Forbidden,       // 403
+            Error::HttpError(HttpError::NotFound) => Status::NotFound,         // 404
+            Error::HttpError(HttpError::Conflict) => Status::Conflict,         // 409
+            Error::HttpError(HttpError::Gone) => Status::Gone,                 // 410
+            Error::HttpError(HttpError::PreconditionFailed) => Status::PreconditionFailed, // 412
+
+            Error::HttpError(_) => Status::InternalServerError, // 500
         };
 
         Response::build().status(status).ok()

--- a/rust/shell/src/api/error.rs
+++ b/rust/shell/src/api/error.rs
@@ -1,109 +1,43 @@
+use rocket::response::{self, Response, Responder};
+use rocket::request::Request;
 use crate::error::{Error, HttpError};
 
-pub type ResponseError = rocket::response::status::Custom<String>;
+#[rocket::async_trait]
+impl<'r> Responder<'r, 'static> for Error {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
+        let status = match self {
+            Error::DotEnvyError(_) |
+            Error::StdEnvVarError(_) |
+            Error::DieselConnectionError(_) |
+            Error::DieselQueryError(_) |
+            Error::HMacError(_) |
+            Error::R2D2Error(_) |
+            Error::LapinError(_) |
+            Error::SendError(_) |
+            Error::RedisError(_) |
+            Error::SerializeError(_) => rocket::http::Status::InternalServerError, // 500
+            
+            #[cfg(feature = "rmqsub")]
+            Error::GeoJSONSerdeError(_) |
+            Error::GeoJsonError(_) |
+            Error::FromUTF8Error(_) |
+            Error::Error => rocket::http::Status::InternalServerError, // 500
 
-impl From<Error> for ResponseError {
-    fn from(value: Error) -> Self {
-        match value {
-            Error::AuthError(e) => rocket::response::status::Custom(
-                rocket::http::Status::Unauthorized,
-                format!("error: {:?}", e).to_string(),
-            ),
-            #[cfg(feature = "rmqsub")]
-            Error::GeoJSONSerdeError(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ),
-            Error::JwtError(e) => rocket::response::status::Custom(
-                rocket::http::Status::Unauthorized,
-                format!("error: {:?}", e).to_string(),
-            ),
-            Error::DotEnvyError(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ), // map every adapters error to 500
-            Error::StdEnvVarError(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ), // map every adapters error to 500
-            Error::DieselConnectionError(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ), // map every adapters error to 500
-            Error::DieselQueryError(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ), // map every adapters error to 500
-            #[cfg(feature = "rmqsub")]
-            Error::FromUTF8Error(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ), // map every adapters error to 500
-            #[cfg(feature = "rmqsub")]
-            Error::GeoJsonError(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ), // map every adapters error to 500
-            Error::HMacError(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ), // map every adapters error to 500
-            Error::R2D2Error(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ), // map every adapters error to 500
-            Error::RedisError(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ), // map every adapters error to 500
-            Error::LapinError(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ), // map every adapters error to 500
-            // map every adapters error to 500
-            Error::SendError(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ), // map every adapters error to 500
-            Error::SerializeError(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ), // map every adapters error to 500
-            Error::HttpError(HttpError::NotFound) => rocket::response::status::Custom(
-                rocket::http::Status::NotFound,
-                "not found".to_string(),
-            ),
-            Error::HttpError(HttpError::Forbidden) => rocket::response::status::Custom(
-                rocket::http::Status::Forbidden,
-                "forbiddon".to_string(),
-            ),
-            Error::HttpError(HttpError::Conflict) => rocket::response::status::Custom(
-                rocket::http::Status::Conflict,
-                "conflict".to_string(),
-            ),
-            Error::HttpError(HttpError::Gone) => {
-                rocket::response::status::Custom(rocket::http::Status::Gone, "gone".to_string())
-            }
-            Error::HttpError(HttpError::Unauthorized) => rocket::response::status::Custom(
-                rocket::http::Status::Unauthorized,
-                "unauthorized".to_string(),
-            ),
-            Error::HttpError(HttpError::NotModified) => rocket::response::status::Custom(
-                rocket::http::Status::NotModified,
-                "not modified".to_string(),
-            ),
-            Error::HttpError(HttpError::PreconditionFailed) => rocket::response::status::Custom(
-                rocket::http::Status::PreconditionFailed,
-                "precondition failed".to_string(),
-            ),
-            Error::HttpError(e) => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                format!("error: {:?}", e).to_string(),
-            ),
-            Error::Error => rocket::response::status::Custom(
-                rocket::http::Status::InternalServerError,
-                "error".to_string(),
-            ),
-        }
+            Error::JwtError(_) |
+            Error::AuthError(_) => rocket::http::Status::Unauthorized, // 401
+
+            Error::HttpError(HttpError::Conflict) => rocket::http::Status::Conflict, // 409
+            Error::HttpError(HttpError::Forbidden) => rocket::http::Status::Forbidden, // 403
+            Error::HttpError(HttpError::Gone) => rocket::http::Status::Gone, // 410
+            Error::HttpError(HttpError::NotFound) => rocket::http::Status::NotFound, // 404
+            Error::HttpError(HttpError::NotModified) => rocket::http::Status::NotModified, // 301
+            Error::HttpError(HttpError::PreconditionFailed) => rocket::http::Status::PreconditionFailed, // 412
+            Error::HttpError(HttpError::Unauthorized) => rocket::http::Status::Unauthorized, // 401
+            Error::HttpError(_) => rocket::http::Status::InternalServerError, // 500
+        };
+
+        Response::build()
+            .status(status)
+            .ok()
     }
 }

--- a/rust/shell/src/api/error.rs
+++ b/rust/shell/src/api/error.rs
@@ -20,9 +20,9 @@ impl<'r> Responder<'r, 'static> for Error {
             | Error::Error => Status::InternalServerError, // 500
 
             #[cfg(feature = "rmqsub")]
-            Error::GeoJSONSerdeError(_)
-            | Error::GeoJsonError(_)
-            | Error::FromUTF8Error(_) => Status::InternalServerError, // 500
+            Error::GeoJSONSerdeError(_) | Error::GeoJsonError(_) | Error::FromUTF8Error(_) => {
+                Status::InternalServerError
+            } // 500
 
             Error::JwtError(_) | Error::AuthError(_) => Status::Unauthorized, // 401
 

--- a/rust/shell/src/api/place.rs
+++ b/rust/shell/src/api/place.rs
@@ -1,4 +1,3 @@
-use super::error::ResponseError;
 use super::{
     check_none_match, get_etag_safe, DbConnWrapper, EtagJson, IfNoneMatchHeader,
     JwtIdentifiedSubject, RedisConnWrapper,
@@ -77,7 +76,7 @@ pub async fn get_places(
     mut redis_conn: RedisConnWrapper,
     subject: Option<JwtIdentifiedSubject>,
     if_none_match: Option<IfNoneMatchHeader>,
-) -> Result<EtagJson<Vec<Place>>, ResponseError> {
+) -> Result<EtagJson<Vec<Place>>, Error> {
     let cache_key = "places".to_string();
     check_none_match(&mut redis_conn, &cache_key, if_none_match)?;
 
@@ -96,7 +95,7 @@ pub async fn get_places_geojson(
     mut redis_conn: RedisConnWrapper,
     subject: Option<JwtIdentifiedSubject>,
     if_none_match: Option<IfNoneMatchHeader>,
-) -> Result<EtagJson<PlaceFeatureCollection>, ResponseError> {
+) -> Result<EtagJson<PlaceFeatureCollection>, Error> {
     let cache_key = "places-geojson".to_string();
     check_none_match(&mut redis_conn, &cache_key, if_none_match)?;
 

--- a/rust/shell/src/api/post.rs
+++ b/rust/shell/src/api/post.rs
@@ -1,4 +1,3 @@
-use super::error::ResponseError;
 use super::{
     check_match, check_none_match, get_etag_safe, DbConnWrapper, JwtIdentifiedSubject,
     RedisConnWrapper,
@@ -92,7 +91,7 @@ pub async fn get_posts(
     mut redis_conn: RedisConnWrapper,
     subject: Option<JwtIdentifiedSubject>,
     if_none_match: Option<IfNoneMatchHeader>,
-) -> Result<EtagJson<Vec<Post>>, ResponseError> {
+) -> Result<EtagJson<Vec<Post>>, Error> {
     let cache_key = "posts".to_string();
     check_none_match(&mut redis_conn, &cache_key, if_none_match)?;
 
@@ -126,7 +125,7 @@ pub fn get_post(
     subject: Option<JwtIdentifiedSubject>,
     id: i32,
     if_none_match: Option<IfNoneMatchHeader>,
-) -> Result<EtagJson<Post>, ResponseError> {
+) -> Result<EtagJson<Post>, Error> {
     let cache_key = format!("posts.{}", id).to_string();
     check_none_match(&mut redis_conn, &cache_key, if_none_match)?;
 
@@ -165,7 +164,7 @@ pub async fn publish_post(
     subject: Option<JwtIdentifiedSubject>,
     id: i32,
     if_match: Option<IfMatchHeader>,
-) -> Result<Status, ResponseError> {
+) -> Result<Status, Error> {
     let cache_key = format!("posts.{}", id).to_string();
     check_match(&mut redis_conn, &cache_key, if_match)?;
 
@@ -223,7 +222,7 @@ pub fn post_post(
     subject: Option<JwtIdentifiedSubject>,
     if_match: Option<IfMatchHeader>,
     data: Form<NewPost>,
-) -> Result<Created<Json<Post>>, ResponseError> {
+) -> Result<Created<Json<Post>>, Error> {
     let cache_key = "posts".to_string();
     check_match(&mut redis_conn, &cache_key, if_match)?;
 
@@ -260,7 +259,7 @@ pub fn delete_post(
     subject: Option<JwtIdentifiedSubject>,
     if_match: Option<IfMatchHeader>,
     id: i32,
-) -> Result<NoContent, ResponseError> {
+) -> Result<NoContent, Error> {
     let cache_key = format!("posts.{}", id).to_string();
     check_match(&mut redis_conn, &cache_key, if_match)?;
 
@@ -316,7 +315,7 @@ pub fn patch_post(
     if_match: Option<IfMatchHeader>,
     id: i32,
     data: Form<PatchPost>,
-) -> Result<NoContent, ResponseError> {
+) -> Result<NoContent, Error> {
     let cache_key = format!("posts.{}", id).to_string();
     check_match(&mut redis_conn, &cache_key, if_match)?;
 

--- a/rust/shell/src/error.rs
+++ b/rust/shell/src/error.rs
@@ -42,7 +42,6 @@ pub enum Error {
     #[cfg(any(feature = "rmqpub", feature = "api"))]
     SerializeError(serde_json::Error),
 
-    #[cfg(feature = "rmqsub")]
     Error, // Generic error
 }
 #[cfg(feature = "api")]
@@ -202,7 +201,6 @@ impl std::fmt::Display for Error {
                 f.write_str(format!("shell error {:?}", error).as_str())
             }
 
-            #[cfg(feature = "rmqsub")]
             Error::Error => f.write_str("shell error"),
         }
     }

--- a/rust/shell/src/error.rs
+++ b/rust/shell/src/error.rs
@@ -42,6 +42,7 @@ pub enum Error {
     #[cfg(any(feature = "rmqpub", feature = "api"))]
     SerializeError(serde_json::Error),
 
+    #[cfg(feature = "rmqsub")]
     Error, // Generic error
 }
 #[cfg(feature = "api")]
@@ -201,6 +202,7 @@ impl std::fmt::Display for Error {
                 f.write_str(format!("shell error {:?}", error).as_str())
             }
 
+            #[cfg(feature = "rmqsub")]
             Error::Error => f.write_str("shell error"),
         }
     }


### PR DESCRIPTION
see #140 item 6

make it so rocket api endpoints can return `Result<T, shell::error::Error>` by implementing responder for Error

see https://rocket.rs/guide/v0.5/responses/#responder

it returns just an http status but that is enough for me now